### PR TITLE
please have a look about this FSTR define

### DIFF
--- a/src/kernel/ports/esp/gnu/compiler.h
+++ b/src/kernel/ports/esp/gnu/compiler.h
@@ -28,7 +28,7 @@ typedef const FAR char *far_string_t;
 /**
  * @brief No special storage for string literals.
  */
-#define FSTR(s) s
+#define FSTR(s) (__extension__({static const char __c[] ICACHE_RODATA_ATTR = (s); &__c[0];}))
 
 #define PACKED __attribute__((packed))
 


### PR DESCRIPTION
i try on my esp12e board, if use

#define FSTR(s) s
```
.pioenvs/esp12e/firmware.elf  :
section            size         addr
.data              1696   1073643520
.rodata           21808   1073645216
.bss              48632   1073667024
.text             25288   1074790400
.irom0.text      298578   1075843088
.xtensa.info         56            0
.comment           9054            0
.debug_line        2433            0
.debug_info        1218            0
.debug_abbrev       100            0
.debug_aranges      160            0
Total            409023
```
and for the pull-request 's define
```
.pioenvs/esp12e/firmware.elf  :
section            size         addr
.data              1696   1073643520
.rodata            3780   1073645216
.bss              48640   1073649000
.text             25288   1074790400
.irom0.text      331462   1075843088
.xtensa.info         56            0
.comment           9054            0
.debug_line        2433            0
.debug_info        1218            0
.debug_abbrev       100            0
.debug_aranges      160            0
Total            423887
```
we saved 18K mem use from rodata to text
but i don't know is there any other problem if use this code
@eerimoq please review the code :)