### PR TITLE
Fix analog 8-15 on Arduino Mega

### DIFF
--- a/src/drivers/ports/avr/adc_port.h
+++ b/src/drivers/ports/avr/adc_port.h
@@ -37,7 +37,9 @@ struct adc_driver_t {
     struct adc_device_t *dev_p;
     struct pin_driver_t pin_drv;
     uint8_t admux;
+#if defined(MUX5)
     uint8_t adcsrb;
+#endif
     long interrupt_count;
     long interrupt_max;
     size_t pos;

--- a/src/drivers/ports/avr/adc_port.h
+++ b/src/drivers/ports/avr/adc_port.h
@@ -37,6 +37,7 @@ struct adc_driver_t {
     struct adc_device_t *dev_p;
     struct pin_driver_t pin_drv;
     uint8_t admux;
+    uint8_t adcsrb;
     long interrupt_count;
     long interrupt_max;
     size_t pos;

--- a/src/drivers/ports/avr/adc_port.i
+++ b/src/drivers/ports/avr/adc_port.i
@@ -54,7 +54,9 @@ ISR(ADC_vect)
         /* Disable ADC hardware if there are no more queued jobs. */
         if (self_p->next_p != NULL) {
             ADMUX = self_p->next_p->admux;
+#if defined(MUX5)
             ADCSRB = self_p->next_p->adcsrb;
+#endif
         } else {
             ADCSRA &= ~_BV(ADEN);
         }
@@ -70,7 +72,11 @@ static void start_adc_hw(struct adc_driver_t *self_p)
 {
     /* Start AD Converter in free running mode. */
     ADMUX = self_p->admux;
+#if defined(MUX5)
     ADCSRB = self_p->adcsrb;
+#else
+    ADCSRB = 0;
+#endif
     /* clock div 32. */
     ADCSRA = (_BV(ADEN) | _BV(ADSC) | _BV(ADATE) | _BV(ADIE)
               | _BV(ADPS2) /*| _BV(ADPS1) */| _BV(ADPS0));
@@ -97,7 +103,9 @@ static int adc_port_init(struct adc_driver_t *self_p,
     self_p->interrupt_max =
         SAMPLING_RATE_TO_INTERRUPT_MAX((long)sampling_rate);
     self_p->admux = (reference | (channel & 0x07));
-    self_p->adcsrb = channel > 7 ? 0x08 : 0;
+#if defined(MUX5)
+    self_p->adcsrb = channel > 7 ? _BV(MUX5) : 0;
+#endif
     pin_init(&self_p->pin_drv, pin_dev_p, PIN_INPUT);
 
     return (0);
@@ -166,9 +174,13 @@ int adc_port_convert_isr(struct adc_driver_t *self_p,
 
     /* Start the convertion. */
     ADMUX = self_p->admux;
+#if defined(MUX5)
     ADCSRB = self_p->adcsrb;
+#else
+    ADCSRB = 0;
+#endif
     ADCSRA = (_BV(ADEN) | _BV(ADSC) | _BV(ADPS2) | _BV(ADPS0));
-    
+
     /* Poll until the convertion is completed. */
     while (ADCSRA & _BV(ADSC));
 


### PR DESCRIPTION
The 2560 requires the MUX5 bit of ADCSRB be set when selecting port K as the source for the ADC.

Without this selecting analog pins 8-15 actually gave readings from pins 0-7.