### PR TITLE
bugfix for mqtt-client

### DIFF
--- a/src/inet/mqtt_client.c
+++ b/src/inet/mqtt_client.c
@@ -161,10 +161,10 @@ static int read_fixed_header(struct mqtt_client_t *self_p,
 static int handle_control_connect(struct mqtt_client_t *self_p)
 {
     int res = 0;
-    uint8_t buf[10];
+    uint8_t buf[12];
 
     /* Write the fixed header. */
-    res = write_fixed_header(self_p, MQTT_CONNECT, 10);
+    res = write_fixed_header(self_p, MQTT_CONNECT, 12);
 
     if (res != 0) {
         return (res);
@@ -178,11 +178,13 @@ static int handle_control_connect(struct mqtt_client_t *self_p)
     buf[4] = 'T';
     buf[5] = 'T';
     buf[6] = 4;
-    buf[7] = 0;
-    buf[8] = (CLEAN_SESSION);
+    buf[7] = (CLEAN_SESSION);
+    buf[8] = 0;
     buf[9] = 10;
+    buf[10] = 0;
+    buf[11] = 0;
 
-    if (chan_write(self_p->transport.out_p, &buf[0], 10) != 10) {
+    if (chan_write(self_p->transport.out_p, &buf[0], 12) != 12) {
         return (-EIO);
     }
 

--- a/tst/inet/mqtt_client/main.c
+++ b/tst/inet/mqtt_client/main.c
@@ -157,7 +157,7 @@ static int test_connect(struct harness_t *harness_p)
     BTASSERT(buf[0] == 0x10);
     BTASSERT(buf[1] == 10);
 
-    BTASSERT(queue_read(&qserverout, buf, 10) == 10);
+    BTASSERT(queue_read(&qserverout, buf, 12) == 12);
     BTASSERT(buf[0] == 0);
     BTASSERT(buf[1] == 4);
     BTASSERT(buf[2] == 'M');
@@ -165,9 +165,11 @@ static int test_connect(struct harness_t *harness_p)
     BTASSERT(buf[4] == 'T');
     BTASSERT(buf[5] == 'T');
     BTASSERT(buf[6] == 4);
-    BTASSERT(buf[7] == 0);
-    BTASSERT(buf[8] == 0x02);
+    BTASSERT(buf[7] == 0x02);
+    BTASSERT(buf[8] == 0);
     BTASSERT(buf[9] == 10);
+    BTASSERT(buf[10] == 0);
+    BTASSERT(buf[11] == 0);
 
     return (0);
 }

--- a/tst/inet/mqtt_client/main.c
+++ b/tst/inet/mqtt_client/main.c
@@ -138,7 +138,7 @@ static int test_connect(struct harness_t *harness_p)
 
     /* Prepare the server to receive the connection message. */
     message.buf_p = NULL;
-    message.size = 12;
+    message.size = 14;
     BTASSERT(queue_write(&qserverin, &message, sizeof(message)) == sizeof(message));
 
     /* Prepare the server to send the connection ack message. */

--- a/tst/inet/mqtt_client/main.c
+++ b/tst/inet/mqtt_client/main.c
@@ -155,7 +155,7 @@ static int test_connect(struct harness_t *harness_p)
 
     BTASSERT(queue_read(&qserverout, buf, 2) == 2);
     BTASSERT(buf[0] == 0x10);
-    BTASSERT(buf[1] == 10);
+    BTASSERT(buf[1] == 12);
 
     BTASSERT(queue_read(&qserverout, buf, 12) == 12);
     BTASSERT(buf[0] == 0);


### PR DESCRIPTION
buf[7] is CLEAN_SESSION, not buf[8]
buf[8] and buf[9] are keepalive
buf[10] and buf[11] are connect payload (is must required)