### PR TITLE
Update can_port.h

### DIFF
--- a/src/drivers/ports/esp32/can_port.h
+++ b/src/drivers/ports/esp32/can_port.h
@@ -31,23 +31,23 @@
 #ifndef __DRIVERS_CAN_PORT_H__
 #define __DRIVERS_CAN_PORT_H__
 
-/* #define CAN_PORT_SPEED_1000KBPS (ESP32_CAN_BTIM0_BRP(0x6)               \ */
-/*                                  | ESP32_CAN_BTIM0_SJW(3)               \ */
-/*                                  | ((ESP32_CAN_BTIM1_TSEG1(2)           \ */
-/*                                      | ESP32_CAN_BTIM1_TSEG2(3)         \ */
-/*                                      | ESP32_CAN_BTIM1_SAM) << 8)) */
+#define CAN_PORT_SPEED_1000KBPS (ESP32_CAN_BTIM0_BRP(0x4)         \
+                                 | ESP32_CAN_BTIM0_SJW(0x1)       \
+                                 | ((ESP32_CAN_BTIM1_TSEG1(0x4)   \
+                                 | ESP32_CAN_BTIM1_TSEG2(0x1)     \
+                                 | ESP32_CAN_BTIM1_SAM) << 8))
+                                   
+#define CAN_PORT_SPEED_500KBPS (ESP32_CAN_BTIM0_BRP(0x4)          \
+                                | ESP32_CAN_BTIM0_SJW(0x1)        \
+                                | ((ESP32_CAN_BTIM1_TSEG1(0xC)    \
+                                | ESP32_CAN_BTIM1_TSEG2(0x1)      \
+                                | ESP32_CAN_BTIM1_SAM) << 8))
 
-#define CAN_PORT_SPEED_500KBPS (ESP32_CAN_BTIM0_BRP(0x4)                \
-                                | ESP32_CAN_BTIM0_SJW(2)                \
-                                | ((ESP32_CAN_BTIM1_TSEG1(7)            \
-                                    | ESP32_CAN_BTIM1_TSEG2(6)          \
-                                    | ESP32_CAN_BTIM1_SAM) << 8))
-
-/* #define CAN_PORT_SPEED_250KBPS (ESP32_CAN_BTIM0_BRP(6)                  \ */
-/*                                 | ESP32_CAN_BTIM0_SJW(3)                \ */
-/*                                 | ((ESP32_CAN_BTIM1_TSEG1(2)            \ */
-/*                                     | ESP32_CAN_BTIM1_TSEG2(3)          \ */
-/*                                     | ESP32_CAN_BTIM1_SAM) << 8)) */
+#define CAN_PORT_SPEED_250KBPS (ESP32_CAN_BTIM0_BRP(0x9)          \
+                                | ESP32_CAN_BTIM0_SJW(0x1)        \
+                                | ((ESP32_CAN_BTIM1_TSEG1(0xC)    \
+                                | ESP32_CAN_BTIM1_TSEG2(0x1)      \
+                                | ESP32_CAN_BTIM1_SAM) << 8))
 
 struct can_device_t {
     struct can_driver_t *drv_p;


### PR DESCRIPTION
CAN BTIM0 and BTIM1 settings adjusted for:
CAN_PORT_SPEED_1000KBPS
CAN_PORT_SPEED_500KBPS
CAN_PORT_SPEED_250KBPS

valued based on http://www.esacademy.com/en/library/calculators/sja1000-timing-calculator.html with 80Mhz Clock