### PR TITLE
Add LED 7-Segment HT16K33 driver.

### DIFF
--- a/doc/library-reference/drivers/led_7seg_ht16k33.rst
+++ b/doc/library-reference/drivers/led_7seg_ht16k33.rst
@@ -1,8 +1,8 @@
 :mod:`led_7seg_ht16k33` --- LED 7-Segment HT16K33
-===========================
+=================================================
 
 .. module:: led_7seg_ht16k33
-   :synopsis: LED Stuff.
+   :synopsis: LED 7-Segment HT16K33
 
 This is a driver for `Adafruit 0.56" 4-Digit 7-Segment Display w/I2C
 Backpack`_ or compatible devices which uses the Holtek HT16K33 chip.

--- a/doc/library-reference/drivers/led_7seg_ht16k33.rst
+++ b/doc/library-reference/drivers/led_7seg_ht16k33.rst
@@ -1,0 +1,20 @@
+:mod:`led_7seg_ht16k33` --- LED 7-Segment HT16K33
+===========================
+
+.. module:: led_7seg_ht16k33
+   :synopsis: LED Stuff.
+
+This is a driver for `Adafruit 0.56" 4-Digit 7-Segment Display w/I2C
+Backpack`_ or compatible devices which uses the Holtek HT16K33 chip.
+
+At this time the driver only supports using the :doc:`i2c_soft` driver
+to communicate with the HT16K33, not the :doc:`i2c` driver.
+
+Source code: :github-blob:`src/drivers/led_7seg_ht16k33.h`,
+:github-blob:`src/drivers/led_7seg_ht16k33.c`
+
+----------------------------------------------
+
+.. doxygenfile:: drivers/led_7seg_ht16k33.h
+   :project: simba
+.. _Adafruit 0.56" 4-Digit 7-Segment Display: https://www.adafruit.com/products/878

--- a/examples/led_7seg_ht16k33/Makefile
+++ b/examples/led_7seg_ht16k33/Makefile
@@ -1,0 +1,35 @@
+#
+# @section License
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2014-2017, Erik Moqvist
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# This file is part of the Simba project.
+#
+
+NAME = led_7seg_ht16k33
+BOARD = nodemcu
+
+SIMBA_ROOT ?= ../..
+include $(SIMBA_ROOT)/make/app.mk

--- a/examples/led_7seg_ht16k33/config.h
+++ b/examples/led_7seg_ht16k33/config.h
@@ -1,0 +1,37 @@
+/**
+ * @section License
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017, Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file is part of the Simba project.
+ */
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+#define CONFIG_MINIMAL_SYSTEM                               1
+#define CONFIG_I2C_SOFT                                     1
+#define CONFIG_LED_7SEG_HT16K33                             1
+#endif

--- a/examples/led_7seg_ht16k33/config.h
+++ b/examples/led_7seg_ht16k33/config.h
@@ -34,4 +34,5 @@
 #define CONFIG_MINIMAL_SYSTEM                               1
 #define CONFIG_I2C_SOFT                                     1
 #define CONFIG_LED_7SEG_HT16K33                             1
+
 #endif

--- a/examples/led_7seg_ht16k33/main.c
+++ b/examples/led_7seg_ht16k33/main.c
@@ -1,0 +1,139 @@
+/**
+ * @section License
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017, Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file is part of the Simba project.
+ */
+
+#include "simba.h"
+
+struct led_7seg_ht16k33_driver_t led;
+struct i2c_soft_driver_t i2c;
+
+void counting(void)
+{
+    int i, mult, dot;
+
+    for (mult = 1, dot = 3; mult <= 0x1000; mult *= 0x10, dot--) {
+        led_7seg_ht16k33_show_dot(&led, dot, true);
+	for (i = 0; i <= 0xf; i++) {
+	    led_7seg_ht16k33_set_num(&led, i * mult, 16);
+	    led_7seg_ht16k33_show_colon(&led, i % 2);
+	    led_7seg_ht16k33_display(&led);
+	    thrd_sleep_ms(500);
+	}
+        led_7seg_ht16k33_show_dot(&led, dot, false);
+    }
+}
+
+void single_cycle(void)
+{
+    led_7seg_ht16k33_set_num(&led, 42, 10);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_set_num(&led, 1234, 10);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_show_colon(&led, true);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_show_colon(&led, false);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    for (int i = 0; i < 4; i++) {
+        led_7seg_ht16k33_show_dot(&led, i, true);
+        led_7seg_ht16k33_display(&led);
+        thrd_sleep(1);
+        led_7seg_ht16k33_show_dot(&led, i, false);
+    }
+
+    for (int i = LED_7SEG_HT16K33_BRIGHTNESS_MIN;
+	 i <= LED_7SEG_HT16K33_BRIGHTNESS_MAX;
+	 i++) {
+        led_7seg_ht16k33_brightness(&led, i);
+        thrd_sleep_ms(250);
+    }
+
+    led_7seg_ht16k33_clear(&led);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_show_colon(&led, true);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_show_colon(&led, false);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_set_num(&led, 1, 10);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_set_num(&led, 10, 10);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_set_num(&led, 100, 10);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_set_num(&led, 1000, 10);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_set_num(&led, 4321, 10);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+
+    led_7seg_ht16k33_set_num(&led, 0xfefe, 16);
+    led_7seg_ht16k33_display(&led);
+    thrd_sleep(1);
+}
+
+int main()
+{
+
+    /* Initialization. */
+    sys_start();
+    led_7seg_ht16k33_module_init();
+    i2c_soft_init(&i2c, &pin_d5_dev, &pin_d6_dev, 50000, 1000000, 1000);
+    led_7seg_ht16k33_init(&led, &i2c, LED_7SEG_HT16K33_DEFAULT_I2C_ADDR);
+    led_7seg_ht16k33_start(&led);
+
+    std_printf("\n\n");
+    std_printf(sys_get_info());
+    while (1) {
+	counting();
+        single_cycle();
+    }
+
+    return (0);
+}

--- a/examples/led_7seg_ht16k33/main.c
+++ b/examples/led_7seg_ht16k33/main.c
@@ -39,18 +39,22 @@ void counting(void)
 
     for (mult = 1, dot = 3; mult <= 0x1000; mult *= 0x10, dot--) {
         led_7seg_ht16k33_show_dot(&led, dot, true);
+
 	for (i = 0; i <= 0xf; i++) {
 	    led_7seg_ht16k33_set_num(&led, i * mult, 16);
 	    led_7seg_ht16k33_show_colon(&led, i % 2);
 	    led_7seg_ht16k33_display(&led);
 	    thrd_sleep_ms(500);
 	}
+
         led_7seg_ht16k33_show_dot(&led, dot, false);
     }
 }
 
 void single_cycle(void)
 {
+    int i;
+
     led_7seg_ht16k33_set_num(&led, 42, 10);
     led_7seg_ht16k33_display(&led);
     thrd_sleep(1);
@@ -67,14 +71,14 @@ void single_cycle(void)
     led_7seg_ht16k33_display(&led);
     thrd_sleep(1);
 
-    for (int i = 0; i < 4; i++) {
+    for (i = 0; i < 4; i++) {
         led_7seg_ht16k33_show_dot(&led, i, true);
         led_7seg_ht16k33_display(&led);
         thrd_sleep(1);
         led_7seg_ht16k33_show_dot(&led, i, false);
     }
 
-    for (int i = LED_7SEG_HT16K33_BRIGHTNESS_MIN;
+    for (i = LED_7SEG_HT16K33_BRIGHTNESS_MIN;
 	 i <= LED_7SEG_HT16K33_BRIGHTNESS_MAX;
 	 i++) {
         led_7seg_ht16k33_brightness(&led, i);
@@ -120,7 +124,6 @@ void single_cycle(void)
 
 int main()
 {
-
     /* Initialization. */
     sys_start();
     led_7seg_ht16k33_module_init();
@@ -128,10 +131,11 @@ int main()
     led_7seg_ht16k33_init(&led, &i2c, LED_7SEG_HT16K33_DEFAULT_I2C_ADDR);
     led_7seg_ht16k33_start(&led);
 
-    std_printf("\n\n");
+    std_printf(OSTR("\r\n"));
     std_printf(sys_get_info());
+
     while (1) {
-	counting();
+        counting();
         single_cycle();
     }
 

--- a/src/config_default.h
+++ b/src/config_default.h
@@ -113,6 +113,7 @@
 #    define PORT_HAS_FLASH
 #    define PORT_HAS_ESP_WIFI
 #    define PORT_HAS_RANDOM
+#    define PORT_HAS_LED_7SEG_HT16K33
 #endif
 
 #if defined(FAMILY_ESP32)
@@ -301,6 +302,17 @@
 #        define CONFIG_RANDOM                               0
 #    else
 #        define CONFIG_RANDOM                               1
+#    endif
+#endif
+
+/**
+ * Enable the led_7seg_ht16k33 driver.
+ */
+#ifndef CONFIG_LED_7SEG_HT16K33
+#    if defined(CONFIG_MINIMAL_SYSTEM) || !defined(PORT_HAS_LED_7SEG_HT16K33)
+#        define CONFIG_LED_7SEG_HT16K33                    0
+#    else
+#        define CONFIG_LED_7SEG_HT16K33                    1
 #    endif
 #endif
 

--- a/src/drivers/led_7seg_ht16k33.c
+++ b/src/drivers/led_7seg_ht16k33.c
@@ -158,8 +158,9 @@ int led_7seg_ht16k33_set_num(struct led_7seg_ht16k33_driver_t *self_p,
     ASSERTN(base <= 16, EINVAL);
 
     for (int i = 0, j = 4; i < 4; i++, j--) {
-        if (i == SEVEN_SEG_COLON_POS)
+        if (i == SEVEN_SEG_COLON_POS) {
             j--;
+	}
         // Avoid leading 0s, but allow a single one.
         if (num || i == 0) {
             int dot = self_p->buf[j] & SEVEN_SEG_DOT;

--- a/src/drivers/led_7seg_ht16k33.c
+++ b/src/drivers/led_7seg_ht16k33.c
@@ -1,0 +1,252 @@
+/**
+ * @section License
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017, Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file is part of the Simba project.
+ */
+
+/*
+ * This is a driver for Adafruit 0.56" 4-Digit 7-Segment Display w/I2C
+ * Backpack which uses the Holtek HT16K33 chip.
+ *
+ * The driver has been tested with: https://www.adafruit.com/products/878
+ *
+ * Datasheet for Holtek HT16K33:
+ * https://cdn-shop.adafruit.com/datasheets/ht16K33v110.pdf
+ *
+ * Protocol:
+ *
+ * The protocol on top of I2C for the chip / display is fairly
+ * simple. One command byte possibly followed by databytes.
+ *
+ * The display has a RAM buffer which we write the digits to.  There
+ * are a number of unused locations, which I presume is because the 7
+ * digit display just doesn't hook those up to LEDs.
+ *
+ * Note that the colon is lid or not based on buffer position 2, so we
+ * need to skip that when dealing with setting numbers in the drivers
+ * internal buffer etc.
+ *
+ * For each digit we use the table from led_7seg_ht16k33_numbertable.i
+ * to light the right LEDs.  We can bitwise-or a digit with
+ * SEVEN_SEG_DOT to turn on the coresponding dot.
+ *
+ * I2C data packet we send is:
+ * - Adddress (also tell display our command is writing to display buffer).
+ * - Digit 0
+ * - Unused
+ * - Digit 1
+ * - Unused
+ * - Colon
+ * - Unused
+ * - Digit 2
+ * - Unused
+ * - Digit 3
+ * - Unused
+ */
+
+#include "simba.h"
+
+#if CONFIG_LED_7SEG_HT16K33 == 1
+
+#include "led_7seg_ht16k33_numbertable.i"
+
+#define HT16K33_CMD_SIZE              0x1
+#define HT16K33_CMD_OSCILLATOR_OFF   0x20
+#define HT16K33_CMD_OSCILLATOR_ON    0x21
+#define HT16K33_CMD_DISPLAY_OFF      0x80
+#define HT16K33_CMD_DISPLAY_ON       0x81
+#define HT16K33_DISPLAY_BLINK_OFF     0x0
+#define HT16K33_DISPLAY_BLINK_2HZ     0x2
+#define HT16K33_CMD_BRIGHTNESS       0xe0
+#define SEVEN_SEG_DIGITS              0x4
+#define SEVEN_SEG_POSITIONS           0x5
+#define SEVEN_SEG_DOT                0x80
+#define SEVEN_SEG_COLON               0x2
+#define SEVEN_SEG_COLON_POS           0x2
+
+/**
+ * Send a one byte command to the display controller.
+ */
+static int i2c_sendcmd(struct led_7seg_ht16k33_driver_t *self_p, uint8_t cmd)
+{
+    int8_t buf[HT16K33_CMD_SIZE];
+    int r;
+
+    buf[0] = cmd;
+    r = i2c_soft_write(self_p->i2c_p, self_p->i2c_addr, buf, HT16K33_CMD_SIZE);
+
+    return (r);
+}
+
+int led_7seg_ht16k33_module_init()
+{
+
+    i2c_soft_module_init();
+
+    return (0);
+}
+
+
+int led_7seg_ht16k33_init(struct led_7seg_ht16k33_driver_t *self_p,
+                          struct i2c_soft_driver_t *i2c_p,
+                          int i2c_addr)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+    ASSERTN(i2c_p != NULL, EINVAL);
+
+    self_p->i2c_p = i2c_p;
+    self_p->i2c_addr = i2c_addr;
+    led_7seg_ht16k33_clear(self_p);
+
+    return (0);
+}
+
+int led_7seg_ht16k33_start(struct led_7seg_ht16k33_driver_t *self_p)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+
+    i2c_soft_start(self_p->i2c_p);
+    if (i2c_soft_scan(self_p->i2c_p, self_p->i2c_addr) != 1) {
+        return (-ENOENT);
+    }
+
+    i2c_sendcmd(self_p, HT16K33_CMD_OSCILLATOR_ON);
+    i2c_sendcmd(self_p, HT16K33_CMD_DISPLAY_ON | HT16K33_DISPLAY_BLINK_OFF);
+    led_7seg_ht16k33_brightness(self_p, LED_7SEG_HT16K33_BRIGHTNESS_MAX);
+
+    return (0);
+}
+
+int led_7seg_ht16k33_clear(struct led_7seg_ht16k33_driver_t *self_p)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+
+    memset(&self_p->buf, 0, sizeof(self_p->buf));
+
+    return (0);
+}
+
+int led_7seg_ht16k33_set_num(struct led_7seg_ht16k33_driver_t *self_p,
+                             int num, int base)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+    ASSERTN(base > 0, EINVAL);
+    ASSERTN(base <= 16, EINVAL);
+
+    for (int i = 0, j = 4; i < 4; i++, j--) {
+        if (i == SEVEN_SEG_COLON_POS)
+            j--;
+        // Avoid leading 0s, but allow a single one.
+        if (num || i == 0) {
+            int dot = self_p->buf[j] & SEVEN_SEG_DOT;
+            self_p->buf[j] = numbertable[num % base] | dot;
+        } else {
+            self_p->buf[j] = 0;
+        }
+        num = num / base;
+    }
+    if (num > 0) {
+        // We could not write complete number
+        return (-ERANGE);
+    }
+
+    return (0);
+}
+
+int led_7seg_ht16k33_show_colon(struct led_7seg_ht16k33_driver_t *self_p,
+                                int show_colon)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+
+    self_p->buf[SEVEN_SEG_COLON_POS] = show_colon ? SEVEN_SEG_COLON : 0;
+
+    return (0);
+}
+
+int led_7seg_ht16k33_show_dot(struct led_7seg_ht16k33_driver_t *self_p,
+                              int position, int show_colon)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+    ASSERTN(position >= 0, EINVAL);
+    ASSERTN(position <= 3, EINVAL);
+
+    if (position >= SEVEN_SEG_COLON_POS)
+        position++;
+
+    if (show_colon) {
+        self_p->buf[position] |= SEVEN_SEG_DOT;
+    } else {
+        self_p->buf[position] &= ~SEVEN_SEG_DOT;
+    }
+
+    return (0);
+}
+
+
+int led_7seg_ht16k33_brightness(struct led_7seg_ht16k33_driver_t *self_p,
+                                int brightness)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+    ASSERTN(brightness >= LED_7SEG_HT16K33_BRIGHTNESS_MIN, EINVAL);
+    ASSERTN(brightness <= LED_7SEG_HT16K33_BRIGHTNESS_MAX, EINVAL);
+
+    int r;
+
+    r = i2c_sendcmd(self_p, HT16K33_CMD_BRIGHTNESS | brightness);
+
+    if (r == 1)
+        return (0);
+    if (r < 0)
+        return (r);
+    return (-EIO);
+}
+
+int led_7seg_ht16k33_display(struct led_7seg_ht16k33_driver_t *self_p)
+{
+    ASSERTN(self_p != NULL, EINVAL);
+
+    uint8_t sendbuf[HT16K33_CMD_SIZE + 2 * SEVEN_SEG_POSITIONS];
+    int i, r;
+
+    // sendbuf[0] will be 0 which is our write command and start address.
+    memset(sendbuf, 0, sizeof(sendbuf));
+    for (i = 0; i < sizeof(self_p->buf); i++)
+        sendbuf[(i * 2) + 1] = self_p->buf[i];
+
+    r = i2c_soft_write(self_p->i2c_p, self_p->i2c_addr, sendbuf,
+                       sizeof(sendbuf));
+
+    if (r == sizeof(sendbuf)) {
+        return (0);
+    }
+    if (r < 0) {
+        return (r);
+    }
+    return (-EIO);
+}
+
+#endif

--- a/src/drivers/led_7seg_ht16k33.h
+++ b/src/drivers/led_7seg_ht16k33.h
@@ -1,0 +1,148 @@
+/**
+ * @section License
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017, Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file is part of the Simba project.
+ */
+
+#ifndef __DRIVERS_LED_7SEG_I2C_H__
+#define __DRIVERS_LED_7SEG_I2C_H__
+
+struct led_7seg_ht16k33_driver_t {
+    struct i2c_soft_driver_t *i2c_p;
+    int i2c_addr;
+    uint8_t buf[5];
+};
+
+//! Minimum brightness.
+#define LED_7SEG_HT16K33_BRIGHTNESS_MIN 0
+//! Maximum brightness.
+#define LED_7SEG_HT16K33_BRIGHTNESS_MAX 0xf
+//! Default I2C address for HT16K33.
+#define LED_7SEG_HT16K33_DEFAULT_I2C_ADDR 0x70
+
+/**
+ * Initialize the driver module. This function must be called before
+ * calling any other function in this module.
+ *
+ * The module will only be initialized once even if this function is
+ * called multiple times.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_module_init(void);
+
+/**
+ * Initialize driver object. The driver object will be used for a
+ * single display.
+ *
+ * @param[out] self_p Driver object to be initialize.
+ * @param[in] i2c_p The I2C driver pointer.
+ * @param[in] i2c_addr The address of the HT16K33 controller.
+ *                     Probably LED_7SEG_HT16K33_DEFAULT_I2C_ADDR.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_init(struct led_7seg_ht16k33_driver_t *self_p,
+                          struct i2c_soft_driver_t *i2c_p,
+                          int i2c_addr);
+/**
+ * Start driver.
+ *
+ * @param[in] self_p Driver object.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_start(struct led_7seg_ht16k33_driver_t *self_p);
+
+/**
+ * Send content of display buffer to the display.
+ *
+ * @param[in] self_p Driver object.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_display(struct led_7seg_ht16k33_driver_t *self_p);
+
+/**
+ * Clear content of display buffer.
+ *
+ * @param[in] self_p Driver object.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_clear(struct led_7seg_ht16k33_driver_t *self_p);
+
+/**
+ * Set display brightness.
+ *
+ * @param[in] self_p Driver object.
+ * @param[in] brightness Brightness from LED_7SEG_HT16K33_BRIGHTNESS_MIN
+ *                       to LED_7SEG_HT16K33_BRIGHTNESS_MAX.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_brightness(struct led_7seg_ht16k33_driver_t *self_p,
+                                int brightness);
+
+/**
+ * Set a number in the display buffer.
+ *
+ * Number cannot be more than 4 digits AKA base^4 - 1.
+ *
+ * @param[in] self_p Driver object.
+ * @param[in] num Number to set.
+ * @param[in] base Base of \a num.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_set_num(struct led_7seg_ht16k33_driver_t *self_p,
+                             int num, int base);
+
+/**
+ * Set show/hide of colon in the display buffer.
+ *
+ * @param[in] self_p Driver object.
+ * @param[in] show_colon If true light colon, otherwise turn off.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_show_colon(struct led_7seg_ht16k33_driver_t *self_p,
+                                int show_colon);
+
+/**
+ * Set show/hide of dot in the display buffer.
+ *
+ * @param[in] self_p Driver object.
+ * @param[in] position The position to light colon or not. Range: 0 to 3.
+ * @param[in] show_dot If true light dot, otherwise turn off.
+ *
+ * @return zero(0) or negative error code.
+ */
+int led_7seg_ht16k33_show_dot(struct led_7seg_ht16k33_driver_t *self_p,
+                              int position, int show_colon);
+
+#endif

--- a/src/drivers/led_7seg_ht16k33.h
+++ b/src/drivers/led_7seg_ht16k33.h
@@ -120,7 +120,8 @@ int led_7seg_ht16k33_brightness(struct led_7seg_ht16k33_driver_t *self_p,
  * @return zero(0) or negative error code.
  */
 int led_7seg_ht16k33_set_num(struct led_7seg_ht16k33_driver_t *self_p,
-                             int num, int base);
+                             int num,
+                             int base);
 
 /**
  * Set show/hide of colon in the display buffer.
@@ -143,6 +144,7 @@ int led_7seg_ht16k33_show_colon(struct led_7seg_ht16k33_driver_t *self_p,
  * @return zero(0) or negative error code.
  */
 int led_7seg_ht16k33_show_dot(struct led_7seg_ht16k33_driver_t *self_p,
-                              int position, int show_colon);
+                              int position,
+                              int show_colon);
 
 #endif

--- a/src/drivers/led_7seg_ht16k33_numbertable.i
+++ b/src/drivers/led_7seg_ht16k33_numbertable.i
@@ -1,0 +1,40 @@
+/***************************************************
+  This is a library for our I2C LED Backpacks
+
+  Designed specifically to work with the Adafruit LED Matrix backpacks
+  ----> http://www.adafruit.com/products/
+  ----> http://www.adafruit.com/products/
+
+  These displays use I2C to communicate, 2 pins are required to
+  interface. There are multiple selectable I2C addresses. For backpacks
+  with 2 Address Select pins: 0x70, 0x71, 0x72 or 0x73. For backpacks
+  with 3 Address Select pins: 0x70 thru 0x77
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  MIT license, all text above must be included in any redistribution
+ ****************************************************/
+
+// Originally from https://github.com/adafruit/Adafruit_LED_Backpack
+
+const uint8_t numbertable[] = {
+	0x3F, /* 0 */
+	0x06, /* 1 */
+	0x5B, /* 2 */
+	0x4F, /* 3 */
+	0x66, /* 4 */
+	0x6D, /* 5 */
+	0x7D, /* 6 */
+	0x07, /* 7 */
+	0x7F, /* 8 */
+	0x6F, /* 9 */
+	0x77, /* a */
+	0x7C, /* b */
+	0x39, /* C */
+	0x5E, /* d */
+	0x79, /* E */
+	0x71, /* F */
+};

--- a/src/simba.h
+++ b/src/simba.h
@@ -218,6 +218,9 @@ extern "C" {
 #ifdef PORT_HAS_RANDOM
 #    include "drivers/random.h"
 #endif
+#ifdef CONFIG_LED_7SEG_HT16K33
+#    include "drivers/led_7seg_ht16k33.h"
+#endif
 #ifdef PORT_HAS_WS2812
 #    include "drivers/ws2812.h"
 #endif

--- a/src/simba.mk
+++ b/src/simba.mk
@@ -178,6 +178,7 @@ DRIVERS_SRC ?= adc.c \
                esp_wifi/softap.c \
                exti.c \
                flash.c \
+               led_7seg_ht16k33.c \
                pin.c \
                pwm_soft.c \
                i2c_soft.c \

--- a/tst/drivers/led_7seg_ht16k33/Makefile
+++ b/tst/drivers/led_7seg_ht16k33/Makefile
@@ -1,0 +1,43 @@
+#
+# @section License
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2014-2017, Erik Moqvist
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# This file is part of the Simba project.
+#
+
+NAME = led_7seg_ht16k33_suite
+TYPE = suite
+BOARD ?= nodemcu
+
+CDEFS += \
+	CONFIG_MINIMAL_SYSTEM=1 \
+	CONFIG_LED_7SEG_HT16K33=1 \
+	CONFIG_I2C_SOFT=1
+
+DRIVERS_SRC = led_7seg_ht16k33.c i2c_soft.c
+
+SIMBA_ROOT ?= ../../..
+include $(SIMBA_ROOT)/make/app.mk

--- a/tst/drivers/led_7seg_ht16k33/config.h
+++ b/tst/drivers/led_7seg_ht16k33/config.h
@@ -1,0 +1,39 @@
+/**
+ * @section License
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017, Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file is part of the Simba project.
+ */
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+#define CONFIG_MINIMAL_SYSTEM                               1
+#define CONFIG_I2C_SOFT                                     1
+#define CONFIG_LED_7SEG_HT16K33                             1
+#define CONFIG_ASSERT                                       1
+#define CONFIG_ASSERT_FORCE_FATAL                           0
+#endif

--- a/tst/drivers/led_7seg_ht16k33/main.c
+++ b/tst/drivers/led_7seg_ht16k33/main.c
@@ -1,0 +1,185 @@
+/**
+ * @section License
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017, Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file is part of the Simba project.
+ */
+
+#include "simba.h"
+
+#define pin_scl_dev pin_d5_dev
+#define pin_sca_dev pin_d6_dev
+
+int test_led_brightness(struct harness_t *harness_p)
+{
+    struct led_7seg_ht16k33_driver_t led;
+    struct i2c_soft_driver_t i2c;
+
+    BTASSERT(i2c_soft_init(&i2c, &pin_scl_dev, &pin_sca_dev, 50000, 1000000,
+			   1000) == 0);
+    BTASSERT(led_7seg_ht16k33_init(&led, &i2c,
+				   LED_7SEG_HT16K33_DEFAULT_I2C_ADDR) == 0);
+    BTASSERT(led_7seg_ht16k33_start(&led) == 0);
+
+    // This isn't pretty, but otherwise we get very long lines.
+    BTASSERT(LED_7SEG_HT16K33_BRIGHTNESS_MIN == 0);
+    BTASSERT(LED_7SEG_HT16K33_BRIGHTNESS_MAX == 0xf);
+
+    std_printf("NOTE: ASSERT errors are expected at this point\r\n");
+    BTASSERT(led_7seg_ht16k33_brightness(&led, -1) == -EINVAL);
+    BTASSERT(led_7seg_ht16k33_brightness(&led, 0) == 0);
+    BTASSERT(led_7seg_ht16k33_brightness(&led, 0xf) == 0);
+    BTASSERT(led_7seg_ht16k33_brightness(&led, 0x10) == -EINVAL);
+
+    return (0);
+}
+
+int test_led_dot(struct harness_t *harness_p)
+{
+    struct led_7seg_ht16k33_driver_t led;
+    struct i2c_soft_driver_t i2c;
+    uint8_t digit;
+
+    BTASSERT(i2c_soft_init(&i2c, &pin_scl_dev, &pin_sca_dev, 50000, 1000000,
+			   1000) == 0);
+    BTASSERT(led_7seg_ht16k33_init(&led, &i2c,
+				   LED_7SEG_HT16K33_DEFAULT_I2C_ADDR) == 0);
+    BTASSERT(led_7seg_ht16k33_start(&led) == 0);
+
+    // We set number before adding / removing dots to verify we will
+    // not nuke them.
+    BTASSERT(led_7seg_ht16k33_set_num(&led, 4444, 10) == 0);
+    digit = led.buf[0];
+    BTASSERT(digit != 0);
+    BTASSERT(led.buf[0] == digit);
+    BTASSERT(led.buf[1] == digit);
+    BTASSERT(led.buf[3] == digit);
+    BTASSERT(led.buf[4] == digit);
+
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 0, true) == 0);
+    BTASSERT(led.buf[0] != digit);
+    BTASSERT(led.buf[1] == digit);
+    BTASSERT(led.buf[3] == digit);
+    BTASSERT(led.buf[4] == digit);
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 0, false) == 0);
+    BTASSERT(led.buf[0] == digit);
+    BTASSERT(led.buf[1] == digit);
+    BTASSERT(led.buf[3] == digit);
+    BTASSERT(led.buf[4] == digit);
+
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 3, true) == 0);
+    BTASSERT(led.buf[0] == digit);
+    BTASSERT(led.buf[1] == digit);
+    BTASSERT(led.buf[3] == digit);
+    BTASSERT(led.buf[4] != digit);
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 3, false) == 0);
+    BTASSERT(led.buf[0] == digit);
+    BTASSERT(led.buf[1] == digit);
+    BTASSERT(led.buf[3] == digit);
+    BTASSERT(led.buf[4] == digit);
+
+    std_printf("NOTE: ASSERT errors are expected at this point\r\n");
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, -1, true) == -EINVAL);
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 0, true) == 0);
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 1, true) == 0);
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 2, true) == 0);
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 3, true) == 0);
+    BTASSERT(led_7seg_ht16k33_show_dot(&led, 4, true) == -EINVAL);
+
+    return (0);
+}
+
+int test_led_colon(struct harness_t *harness_p)
+{
+    struct led_7seg_ht16k33_driver_t led;
+    struct i2c_soft_driver_t i2c;
+
+    BTASSERT(i2c_soft_init(&i2c, &pin_scl_dev, &pin_sca_dev, 50000, 1000000,
+			   1000) == 0);
+    BTASSERT(led_7seg_ht16k33_init(&led, &i2c,
+				   LED_7SEG_HT16K33_DEFAULT_I2C_ADDR) == 0);
+    BTASSERT(led_7seg_ht16k33_start(&led) == 0);
+
+    BTASSERT(led.buf[0] == 0);
+
+    BTASSERT(led_7seg_ht16k33_show_colon(&led, true) == 0);
+    BTASSERT(led.buf[2] != 0);
+
+    BTASSERT(led_7seg_ht16k33_show_colon(&led, false) == 0);
+    BTASSERT(led.buf[2] == 0);
+
+    return (0);
+}
+
+int test_led_send_nums(struct harness_t *harness_p)
+{
+    struct led_7seg_ht16k33_driver_t led;
+    struct i2c_soft_driver_t i2c;
+
+    BTASSERT(i2c_soft_init(&i2c, &pin_scl_dev, &pin_sca_dev, 50000, 1000000,
+			   1000) == 0);
+    BTASSERT(led_7seg_ht16k33_init(&led, &i2c,
+				   LED_7SEG_HT16K33_DEFAULT_I2C_ADDR) == 0);
+    BTASSERT(led_7seg_ht16k33_start(&led) == 0);
+
+    // Make sure buffer is empty from start.
+    for (int i = 0; i < sizeof(led.buf); i++) {
+	BTASSERT(led.buf[i] == 0);
+    }
+
+    BTASSERT(led_7seg_ht16k33_set_num(&led, 42, 10) == 0);
+    BTASSERT(led_7seg_ht16k33_display(&led) == 0);
+    time_busy_wait_us(500000); // 0.5s
+
+    BTASSERT(led_7seg_ht16k33_set_num(&led, 4242, 10) == 0);
+    BTASSERT(led_7seg_ht16k33_display(&led) == 0);
+    time_busy_wait_us(500000); // 0.5s
+
+    BTASSERT(led_7seg_ht16k33_set_num(&led, 10000, 10) == -ERANGE);
+    BTASSERT(led_7seg_ht16k33_set_num(&led, 10000, 16) == 0);
+
+    return (0);
+}
+
+int main()
+{
+    struct harness_t harness;
+    struct harness_testcase_t harness_testcases[] = {
+        { test_led_send_nums, "led_send_nums" },
+        { test_led_brightness, "test_led_brightness" },
+        { test_led_dot, "test_led_dot" },
+        { test_led_colon, "test_led_colon" },
+        { NULL, NULL }
+    };
+
+    sys_start();
+    led_7seg_ht16k33_module_init();
+
+    harness_init(&harness);
+    harness_run(&harness, harness_testcases);
+
+    return (0);
+}


### PR DESCRIPTION
This driver allows controlling Adafruit 0.56" 4-Digit 7-Segment
Display w/I2C Backpack.

I tried to follow coding conversion from other files, but not sure how much I got it right.

Do comment on the patch etc. and I can fix things instead of you having to do it later.

For now only added it to the nodemcu board, as that's the one I have tested it on. That said, I see no reason it shouldn't work on other boards using i2c_soft driver.

PS. I did the work entirely in my own spare time, but the simple way to release patches like this means my dayjob retains copyright, and for code which is under MIT this shouldn't really matter.