### PR TITLE
Fix setup.sh conditional to work in all shells.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # in your shell to setup the environment.
 #
 
-if [ "${OSTYPE}" == "linux-gnu" ]; then
+if [ "${OSTYPE}" = "linux-gnu" ]; then
     source environment/setup_linux.sh
 else
     echo "\$\{OSTYPE\} must be linux-gnu."


### PR DESCRIPTION
The UNIX standard string operator in test / "[" is "=". Some shells
like bash have added "==", but it fails e.g. in zsh.