### PR TITLE
Add support for the DS18B20 driver on ESP8266 boards.

### DIFF
--- a/src/config_default.h
+++ b/src/config_default.h
@@ -108,6 +108,8 @@
 #    define PORT_HAS_SPI
 #    define PORT_HAS_UART
 #    define PORT_HAS_UART_SOFT
+#    define PORT_HAS_OWI
+#    define PORT_HAS_DS18B20
 #    define PORT_HAS_ADC
 #    define PORT_HAS_ANALOG_INPUT_PIN
 #    define PORT_HAS_FLASH

--- a/src/drivers/ds18b20.c
+++ b/src/drivers/ds18b20.c
@@ -47,7 +47,7 @@ struct ds18b20_scratchpad_t {
     uint8_t configuration;
     uint8_t reserved[3];
     uint8_t crc;
-};
+} PACKED;
 
 struct module_t {
     int initialized;

--- a/src/simba.mk
+++ b/src/simba.mk
@@ -173,12 +173,14 @@ endif
 ifeq ($(FAMILY),esp)
 DRIVERS_SRC ?= adc.c \
 	       analog_input_pin.c \
+	       ds18b20.c \
 	       esp_wifi.c \
 	       esp_wifi/station.c \
 	       esp_wifi/softap.c \
 	       exti.c \
 	       flash.c \
 	       led_7seg_ht16k33.c \
+	       owi.c \
 	       pin.c \
 	       pwm_soft.c \
 	       i2c_soft.c \


### PR DESCRIPTION
This change also fixes alignment of struct ds18b20_scratchpad_t by
adding PACKED.

The ESP8266 uses different alignment than the 8 bit AVR (where DS18B20
worked fine), which resulted in struct ds18b20_scratchpad_t being
alligned incorrectly, causing the CRC check to fail.  That took a
while to track down as the root cause.

Tested on WEMOS D1 mini, Arduino Nano.