### PR TITLE
ESP8266 - specifying station BSSID to connect to

### DIFF
--- a/doc/library-reference/drivers/esp_wifi.rst
+++ b/doc/library-reference/drivers/esp_wifi.rst
@@ -14,7 +14,7 @@ will accept connections to the SSID `Simba`.
 
    esp_wifi_set_op_mode(esp_wifi_op_mode_station_softap_t);
    esp_wifi_softap_init("Simba", NULL);
-   esp_wifi_station_init("ssid", "password", NULL);
+   esp_wifi_station_init("ssid", "password", NULL, NULL);
 
 Configure the WiFi as an Access Point. The application will accept
 connections to the SSID `Simba`.
@@ -30,7 +30,18 @@ Wifi with SSID `ssid`.
 .. code-block:: c
 
    esp_wifi_set_op_mode(esp_wifi_op_mode_station_t);
-   esp_wifi_station_init("ssid", "password", NULL);
+   esp_wifi_station_init("ssid", "password", NULL, NULL);
+
+Configure the WiFi as a Station specifying the MAC address of the
+access point. The application tries to connect to a Wifi with
+a MAC of `c8:d7:19:0f:04:66` and SSID `ssid`.
+
+.. code-block:: c
+
+   esp_wifi_set_op_mode(esp_wifi_op_mode_station_t);
+   esp_wifi_station_init("ssid", "password",
+                         (uint8_t[]){0xc8, 0xd7, 0x19, 0x0f, 0x04, 0x66},
+                         NULL);
 
 ----------------------------------------------
 

--- a/examples/esp_wifi/station/main.c
+++ b/examples/esp_wifi/station/main.c
@@ -43,7 +43,8 @@ int main()
     inet_aton("255.255.255.0", &info.netmask);
     inet_aton("192.168.0.1", &info.gateway);
 
-    if (esp_wifi_station_init("Qvist2", "maxierik",
+    if (esp_wifi_station_init("Qvist2",
+                              "maxierik",
                               (uint8_t[]){0xc8, 0xd7, 0x19, 0x0f, 0x04, 0x66},
                               &info) != 0) {
         std_printf(FSTR("Failed to configure the Station.\r\n"));

--- a/examples/esp_wifi/station/main.c
+++ b/examples/esp_wifi/station/main.c
@@ -43,7 +43,9 @@ int main()
     inet_aton("255.255.255.0", &info.netmask);
     inet_aton("192.168.0.1", &info.gateway);
 
-    if (esp_wifi_station_init("Qvist2", "maxierik", &info) != 0) {
+    if (esp_wifi_station_init("Qvist2", "maxierik",
+                              (uint8_t[]){0xc8, 0xd7, 0x19, 0x0f, 0x04, 0x66},
+                              &info) != 0) {
         std_printf(FSTR("Failed to configure the Station.\r\n"));
     }
 

--- a/examples/esp_wifi/station/main.c
+++ b/examples/esp_wifi/station/main.c
@@ -45,7 +45,7 @@ int main()
 
     if (esp_wifi_station_init("Qvist2",
                               "maxierik",
-                              (uint8_t[]){0xc8, 0xd7, 0x19, 0x0f, 0x04, 0x66},
+                              (uint8_t[]){0xc8, 0xd7, 0x19, 0x0f, 0x04, 0x65},
                               &info) != 0) {
         std_printf(FSTR("Failed to configure the Station.\r\n"));
     }

--- a/examples/esp_wifi/station_softap/main.c
+++ b/examples/esp_wifi/station_softap/main.c
@@ -42,7 +42,7 @@ int main()
         std_printf(FSTR("Failed to configure the Soft AP.\r\n"));
     }
 
-    if (esp_wifi_station_init("Qvist2", "maxierik", NULL) != 0) {
+    if (esp_wifi_station_init("Qvist2", "maxierik", NULL, NULL) != 0) {
         std_printf(FSTR("Failed to configure the Station.\r\n"));
     }
 

--- a/src/drivers/esp_wifi/station.c
+++ b/src/drivers/esp_wifi/station.c
@@ -34,10 +34,12 @@
 
 int esp_wifi_station_init(const char *ssid_p,
                           const char *password_p,
+                          const uint8_t *bssid_p,
                           const struct inet_if_ip_info_t *info_p)
 {
     return (esp_wifi_station_port_init(ssid_p,
                                        password_p,
+                                       bssid_p,
                                        info_p));
 }
 

--- a/src/drivers/esp_wifi/station.h
+++ b/src/drivers/esp_wifi/station.h
@@ -57,6 +57,7 @@ enum esp_wifi_station_status_t {
  */
 int esp_wifi_station_init(const char *ssid_p,
                           const char *password_p,
+                          const uint8_t *bssid_p,
                           const struct inet_if_ip_info_t *info_p);
 
 /**

--- a/src/drivers/ports/esp/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp/esp_wifi_port/station.i
@@ -39,7 +39,7 @@
 #include "espressif/esp_misc.h"
 #include "espressif/esp_sta.h"
 
-static struct station_config config = {0};
+static struct station_config config = {{0}};
 
 static int esp_wifi_station_port_init(const char *ssid_p,
                                       const char *password_p,

--- a/src/drivers/ports/esp/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp/esp_wifi_port/station.i
@@ -39,7 +39,7 @@
 #include "espressif/esp_misc.h"
 #include "espressif/esp_sta.h"
 
-static struct station_config config;
+static struct station_config config = {0};
 
 static int esp_wifi_station_port_init(const char *ssid_p,
                                       const char *password_p,

--- a/src/drivers/ports/esp/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp/esp_wifi_port/station.i
@@ -63,7 +63,7 @@ static int esp_wifi_station_port_init(const char *ssid_p,
 
     if (bssid_p != NULL) {
         config.bssid_set = 1;
-        memcpy(config.bssid, bssid_p, 6);
+        memcpy(config.bssid, bssid_p, sizeof(config.bssid));
     }
 
     /* Static or dynamic ip. */

--- a/src/drivers/ports/esp/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp/esp_wifi_port/station.i
@@ -43,6 +43,7 @@ static struct station_config config;
 
 static int esp_wifi_station_port_init(const char *ssid_p,
                                       const char *password_p,
+                                      const uint8_t *bssid_p,
                                       const struct inet_if_ip_info_t *info_p)
 {
     ASSERTN(ssid_p != NULL, EINVAL);
@@ -58,6 +59,11 @@ static int esp_wifi_station_port_init(const char *ssid_p,
         strcpy((char *)config.password, password_p);
     } else {
         config.password[0] = 0;
+    }
+
+    if (bssid_p != NULL) {
+        config.bssid_set = 1;
+        memcpy(config.bssid, bssid_p, 6);
     }
 
     /* Static or dynamic ip. */

--- a/src/drivers/ports/esp/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp/esp_wifi_port/station.i
@@ -64,6 +64,8 @@ static int esp_wifi_station_port_init(const char *ssid_p,
     if (bssid_p != NULL) {
         config.bssid_set = 1;
         memcpy(config.bssid, bssid_p, sizeof(config.bssid));
+    } else {
+        config.bssid_set = 0;
     }
 
     /* Static or dynamic ip. */

--- a/src/drivers/ports/esp32/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp32/esp_wifi_port/station.i
@@ -47,6 +47,7 @@ static enum esp_wifi_station_status_t connection_status = esp_wifi_station_statu
 
 static int esp_wifi_station_port_init(const char *ssid_p,
                                       const char *password_p,
+                                      const uint8_t *bssid_p,
                                       const struct inet_if_ip_info_t *info_p)
 {
     ASSERTN(ssid_p != NULL, EINVAL);
@@ -62,6 +63,11 @@ static int esp_wifi_station_port_init(const char *ssid_p,
         strcpy((char *)config.password, password_p);
     } else {
         config.password[0] = 0;
+    }
+
+    if (bssid_p != NULL) {
+        config.bssid_set = 1;
+        memcpy(config.bssid, bssid_p, sizeof(config.bssid));
     }
 
     /* Static or dynamic ip. */
@@ -137,7 +143,7 @@ static int esp_wifi_station_port_get_reconnect_policy(void)
 int esp_wifi_station_port_set_connect_status(enum esp_wifi_station_status_t status)
 {
     connection_status = status;
-    
+
     return (0);
 }
 

--- a/src/drivers/ports/esp32/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp32/esp_wifi_port/station.i
@@ -42,7 +42,7 @@
 
 #include "esp_wifi.h"
 
-static wifi_sta_config_t config = {0};
+static wifi_sta_config_t config = {{0}};
 static enum esp_wifi_station_status_t connection_status = esp_wifi_station_status_idle_t;
 
 static int esp_wifi_station_port_init(const char *ssid_p,

--- a/src/drivers/ports/esp32/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp32/esp_wifi_port/station.i
@@ -42,7 +42,7 @@
 
 #include "esp_wifi.h"
 
-static wifi_sta_config_t config;
+static wifi_sta_config_t config = {0};
 static enum esp_wifi_station_status_t connection_status = esp_wifi_station_status_idle_t;
 
 static int esp_wifi_station_port_init(const char *ssid_p,

--- a/src/drivers/ports/esp32/esp_wifi_port/station.i
+++ b/src/drivers/ports/esp32/esp_wifi_port/station.i
@@ -68,6 +68,8 @@ static int esp_wifi_station_port_init(const char *ssid_p,
     if (bssid_p != NULL) {
         config.bssid_set = 1;
         memcpy(config.bssid, bssid_p, sizeof(config.bssid));
+    } else {
+        config.bssid_set = 0;
     }
 
     /* Static or dynamic ip. */

--- a/src/inet/network_interface/driver/esp.c
+++ b/src/inet/network_interface/driver/esp.c
@@ -50,8 +50,8 @@ static int esp_station_start(void *arg_p,
     if (esp_wifi_set_op_mode(mode) != 0) {
         return (-1);
     }
-    
-    esp_wifi_station_init(ssid_p, password_p, info_p);
+
+    esp_wifi_station_init(ssid_p, password_p, arg_p, info_p);
     esp_wifi_station_connect();
 
     return (0);

--- a/src/inet/network_interface/wifi.h
+++ b/src/inet/network_interface/wifi.h
@@ -74,7 +74,9 @@ int network_interface_wifi_module_init(void);
  * @param[in] self_p The WiFi network interface to initialize.
  * @param[in] name_p Name to assign the to interface.
  * @param[in] driver_p Driver virtualization callbacks to use.
- * @param[in] arg_p Argument passed to the driver callbacks.
+ * @param[in] arg_p Argument passed to the driver callbacks. In case
+ *            of ESP chips and WiFi station mode - compound
+ *            literal of uint8_t[6] specifying the access point MAC.
  * @param[in] ssid_p Access Point SSID.
  * @param[in] password_p Access Point password.
  *

--- a/tst/drivers/esp_wifi/main.c
+++ b/tst/drivers/esp_wifi/main.c
@@ -87,6 +87,7 @@ static int test_station(struct harness_t *harness_p)
     BTASSERT(esp_wifi_set_op_mode(esp_wifi_op_mode_station_t) == 0);
     BTASSERT(esp_wifi_station_init(STRINGIFY(SSID),
                                    STRINGIFY(PASSWORD),
+                                   NULL,
                                    NULL) == 0);
     BTASSERT(esp_wifi_station_connect() == 0);
 


### PR DESCRIPTION
Hello,
[noob alert]
Seems like Simba doesn't have an option to specify WiFi station BSSID to connect to. This is important when connecting to multi-AP WiFi network because SDK is too dumb to figure out which AP to connect to on its own.
Espressiv SDK does support this via the station_config struct. I'm wondering whether it's planned to add this into Simba, or am I just missing something?