### PR TITLE
Fixed HTTP server page routing

### DIFF
--- a/src/inet/http_server.c
+++ b/src/inet/http_server.c
@@ -251,7 +251,7 @@ find_route_callback(struct http_server_t *self_p,
     route_p = self_p->routes_p;
 
     while (route_p->path_p != NULL) {
-        if (strncmp(route_p->path_p, path_p, strlen(route_p->path_p)) == 0) {
+        if (strncmp(route_p->path_p, path_p, strlen(path_p)) == 0) {
             return (route_p->callback);
         }
 


### PR DESCRIPTION
Hi,
Without this fix find_route_callback() always calls '/' callback