### PR TITLE
http_server_response_write() never returns if transmission is interrupted [ESP8266]

### DIFF
--- a/src/inet/socket.c
+++ b/src/inet/socket.c
@@ -595,7 +595,7 @@ static err_t on_tcp_recv(void *arg_p,
             resume_if_polled(socket_p);
         }
 
-        if(socket_p->output.cb.state == STATE_SENDTO) {
+        if (socket_p->output.cb.state == STATE_SENDTO) {
             resume_thrd(socket_p->output.cb.thrd_p, 0);
         }
     }


### PR DESCRIPTION
Hi!
Found a problem with the HTTP server. http_server_response_write() never returns if transmission is interrupted on client side - subsequent page requests are not being responded to. This is with ESP8266 - not sure whether other ports are affected. Steps to reproduce:
1) Flash the HTTP server example
2) Ctrl+C while curl is downloading page
```bash
eimis@e6430 ~/Projects/simba $ curl -i http://192.168.1.183
HTTP/1.1 200 OK
Content-Type: text/html
Content-Length: 9748


<!DOCTYPE html> <html> <head> <meta ^C
```
3) Subsequent curl calls never return or produce:
```bash
eimis@e6430 ~/Projects/simba $ curl -i http://192.168.1.183
curl: (56) Recv failure: Connection reset by peer
```
My guess is that chan_write() inside of http_server_response_write() never returns. I'd surely investigate this further but I'm not sure how to setup debugging on the ESP8266.
While http_server_response_write() is stuck ESP is still responsive via Simba shell.

