### PR TITLE
mqtt_client: Make on_error callback optional by providing a default.

### DIFF
--- a/src/inet/mqtt_client.c
+++ b/src/inet/mqtt_client.c
@@ -747,6 +747,20 @@ static int read_server_message(struct mqtt_client_t *self_p)
     return (res);
 }
 
+/**
+ * Default on_error callback used if application has not provided one.
+ */
+static int default_on_error(struct mqtt_client_t *self_p,
+                            int error)
+{
+    log_object_print(self_p->log_object_p,
+                     LOG_ERROR,
+                     OSTR("mqtt_client error: %d.\r\n"),
+                     error);
+
+    return (0);
+}
+
 int mqtt_client_init(struct mqtt_client_t *self_p,
                      const char *name_p,
                      struct log_object_t *log_object_p,
@@ -755,6 +769,10 @@ int mqtt_client_init(struct mqtt_client_t *self_p,
                      mqtt_on_publish_t on_publish,
                      mqtt_on_error_t on_error)
 {
+    if (on_error == NULL) {
+        on_error = default_on_error;
+    }
+
     self_p->name_p = name_p;
     self_p->log_object_p = log_object_p;
     self_p->state = mqtt_client_state_disconnected_t;

--- a/src/inet/mqtt_client.h
+++ b/src/inet/mqtt_client.h
@@ -124,7 +124,7 @@ struct mqtt_application_message_t {
  * @param[in] on_publish On-publish callback function. Called when the
  *                       server publishes a message.
  * @param[in] on_error On-error callback function. Called when an error
- *                     occurs.
+ *                     occurs. If NULL, a default handler is used.
  *
  * @return zero(0) or negative error code.
  */

--- a/tst/inet/mqtt_client_network/main.c
+++ b/tst/inet/mqtt_client_network/main.c
@@ -30,8 +30,13 @@
 
 #include "simba.h"
 
+#ifndef REMOTE_HOST_IP
 #define REMOTE_HOST_IP   192.168.0.4
+#endif
+
+#ifndef REMOTE_HOST_PORT
 #define REMOTE_HOST_PORT       10000
+#endif
 
 struct message_t {
     void *buf_p;
@@ -60,14 +65,6 @@ static size_t on_publish(struct mqtt_client_t *client_p,
     return (0);
 }
 
-static int on_error(struct mqtt_client_t *client_p,
-                    int error)
-{
-    std_printf(FSTR("error = %d\r\n"), error);
-
-    return (0);
-}
-
 static int test_init(struct harness_t *harness_p)
 {
     struct thrd_t *thrd_p;
@@ -91,7 +88,7 @@ static int test_init(struct harness_t *harness_p)
                               &server_sock,
                               &server_sock,
                               on_publish,
-                              on_error) == 0);
+                              NULL) == 0);
 
     thrd_p = thrd_spawn(mqtt_client_main,
                         &client,

--- a/tst/inet/mqtt_client_network/main.c
+++ b/tst/inet/mqtt_client_network/main.c
@@ -31,11 +31,11 @@
 #include "simba.h"
 
 #ifndef REMOTE_HOST_IP
-#define REMOTE_HOST_IP   192.168.0.4
+#   define REMOTE_HOST_IP   192.168.0.4
 #endif
 
 #ifndef REMOTE_HOST_PORT
-#define REMOTE_HOST_PORT       10000
+#   define REMOTE_HOST_PORT       10000
 #endif
 
 struct message_t {


### PR DESCRIPTION
The default simply logs an error using the existing log object.

In many cases the isn't a lot useful to do in the error call back, so
just logging an error by default means less code in the common case.

Use new NULL on_error callback in mqtt_client_network test, and make
it possible to override REMOTE_HOST_IP and REMOTE_HOST_PORT on the
command line.