### PR TITLE
Switch around the esp8266 default i2c0 SCL/SDA pins.

### DIFF
--- a/src/mcus/esp8266/mcu.c
+++ b/src/mcus/esp8266/mcu.c
@@ -105,8 +105,8 @@ struct flash_device_t flash_device[FLASH_DEVICE_MAX] = {
 /* Software i2c on ESP8266. */
 struct i2c_device_t i2c_device[I2C_DEVICE_MAX] = {
     {
-        .scl_p = &pin_device[4],
-        .sda_p = &pin_device[5],
+        .scl_p = &pin_device[5],
+        .sda_p = &pin_device[4],
         .max_clock_stretching_us = 100000,
         .clock_stretching_sleep_us = 1000
     },


### PR DESCRIPTION
This makes SCL = gpio5 and SDA = gpio4, which matches both WEMOS D1
Mini and Adafruit Feather HUZZAH ESP8266 documented I2C pins.

Those were the two ESP8266 boards I found which defined default I2C
pins, probably because they both supports shields (so it matters which
pins you use).

While the Adafruit Feather HUZZAH ESP8266 is not yet supported by
Simba, it's likely to be in the future...

References:

https://wiki.wemos.cc/products:d1:d1_mini
https://learn.adafruit.com/adafruit-feather-huzzah-esp8266/pinouts