### PR TITLE
Add an mqtt_client example and improve documentation.

### DIFF
--- a/doc/library-reference/inet/mqtt_client.rst
+++ b/doc/library-reference/inet/mqtt_client.rst
@@ -10,11 +10,65 @@ MQTT is a publish-subscribe-based lightweight messaging protocol.
           transport layer (normally TCP). That has to be set up using
           channels.
 
+The driver works by running the processing code in a thread which
+communicate with the MQTT broker on one side using channels, and the
+application on the other side using queues.
+
+This means the application has to set up appropriate channels, which
+is already ready to communicate with the MQTT server, e.g. using TCP,
+and the thread running the MQTT client.
+
+Basic example of initializing MQTT over TCP (error checking left out
+for brevity).
+
+.. code-block:: c
+
+   static size_t on_publish(struct mqtt_client_t *client_p,
+                            const char *topic_p,
+                            void *chin_p,
+                            size_t size)
+   {
+       uint8_t buf[32];
+
+       chan_read(chin_p, buf, size);
+       buf[size] = '\0';
+       std_printf(OSTR("on_publish: %s\r\n"), &buf[0]);
+
+       return (0);
+   }
+
+.. code-block:: c
+
+   struct inet_addr_t remote_host_address;
+
+   inet_aton("127.0.0.1", &remote_host_address.ip);
+   remote_host_address.port = 1883;
+   socket_open_tcp(&server_sock);
+   socket_connect(&server_sock, &remote_host_address);
+
+   mqtt_client_init(&client,
+                    "mqtt_client",
+                    NULL,
+                    &server_sock,
+                    &server_sock,
+                    on_publish,
+                    NULL);
+
+   thrd_spawn(mqtt_client_main,
+              &client,
+              0,
+              stack,
+              sizeof(stack));
+
+   mqtt_client_connect(&client);
+
 Source code: :github-blob:`src/inet/mqtt_client.h`, :github-blob:`src/inet/mqtt_client.c`
 
 Test code: :github-blob:`tst/inet/mqtt_client/main.c`
 
 Test coverage: :codecov:`src/inet/mqtt_client.c`
+
+Example code: :github-blob:`examples/mqtt_client/main.c`
 
 ----------------------------------------------
 

--- a/examples/mqtt_client/Makefile
+++ b/examples/mqtt_client/Makefile
@@ -1,0 +1,45 @@
+#
+# @section License
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2014-2017, Erik Moqvist
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# This file is part of the Simba project.
+#
+
+NAME = mqtt_client
+BOARD ?= nodemcu
+
+SSID ?= Qvist2
+PASSWORD ?= maxierik
+
+CDEFS += \
+	CONFIG_MODULE_INIT_LOG=1 \
+	CONFIG_START_NETWORK=1 \
+	CONFIG_START_NETWORK_INTERFACE_WIFI_SSID=$(SSID) \
+	CONFIG_START_NETWORK_INTERFACE_WIFI_PASSWORD=$(PASSWORD)
+
+
+SIMBA_ROOT ?= ../../..
+include $(SIMBA_ROOT)/make/app.mk

--- a/examples/mqtt_client/main.c
+++ b/examples/mqtt_client/main.c
@@ -1,0 +1,271 @@
+/**
+ * @section License
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017, Erik Moqvist
+ * Copyright (c) 2017, Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file is part of the Simba project.
+ */
+
+#include "simba.h"
+
+#ifndef REMOTE_HOST_IP
+#   define REMOTE_HOST_IP   192.168.0.4
+#endif
+
+#ifndef REMOTE_HOST_PORT
+#   define REMOTE_HOST_PORT       10000
+#endif
+
+struct message_t {
+    void *buf_p;
+    size_t size;
+};
+
+static struct socket_t server_sock;
+static struct mqtt_client_t client;
+
+static THRD_STACK(stack, 4096);
+int message_count = 0;
+
+//! Callback when we get an message from the MQTT broker.
+static size_t on_publish(struct mqtt_client_t *client_p,
+                         const char *topic_p,
+                         void *chin_p,
+                         size_t size)
+{
+    uint8_t buf[16];
+    int unread, toread;
+
+    std_printf(OSTR("on_publish: %s = "), topic_p);
+
+    /*
+     * We read the value in chunks as our buffer may be to small, as
+     * MQTT allows up to 256MB messages. This complicates the code a
+     * bit, but we must read all the bytes from the channel to avoid
+     * getting out of sync with the mqtt_client thread.
+     */
+    for (unread = size; unread > 0; unread -= toread) {
+        toread = MIN(unread, sizeof(buf) - 1);
+        chan_read(chin_p, buf, toread);
+        buf[toread] = '\0';
+        std_printf(OSTR("%s"), &buf[0]);
+    }
+
+    std_printf(OSTR("\r\n"));
+
+    message_count++;
+
+    return (0);
+}
+
+static int mqtt_init(void)
+{
+    struct thrd_t *thrd_p;
+    int port = REMOTE_HOST_PORT;
+    char remote_host_ip[] = STRINGIFY(REMOTE_HOST_IP);
+    struct inet_addr_t remote_host_address;
+    int ret;
+
+    /* Setup TCP connection to MQTT broker */
+    std_printf(OSTR("Connecting to MQTT Broker '%s:%d'.\r\n"),
+               emote_host_ip,
+               port);
+    remote_host_address.port = port;
+    ret = inet_aton(remote_host_ip, &remote_host_address.ip);
+
+    if (ret != 0) {
+        std_printf(OSTR("Failed to convert '%s' to IP address: %d'\r\n"),
+                   remote_host_ip,
+                   ret);
+        return (ret);
+    }
+
+    ret = socket_open_tcp(&server_sock);
+
+    if (ret != 0) {
+        std_printf(OSTR("Failed to open TCP socket: %d'\r\n"),
+                   ret);
+        return (ret);
+    }
+
+    ret = socket_connect(&server_sock, &remote_host_address);
+
+    if (ret != 0) {
+        std_printf(OSTR("Failed to connect TCP socket to broker: %d'\r\n"),
+                   ret);
+        return (ret);
+    }
+
+    ret = mqtt_client_init(&client,
+                           "mqtt_client",
+                           NULL,
+                           &server_sock,
+                           &server_sock,
+                           on_publish,
+                           NULL);
+
+    if (ret != 0) {
+        std_printf(OSTR("Failed to initialized MQTT client: %d'\r\n"),
+                   ret);
+        return (ret);
+    }
+
+    /* Start the thread which will do the actual work */
+    thrd_p = thrd_spawn(mqtt_client_main,
+                        &client,
+                        0,
+                        stack,
+                        sizeof(stack));
+
+    if (thrd_p == NULL) {
+        std_printf(OSTR("Failed to spawn thread for MQTT client'\r\n"));
+        return (-1);
+    }
+
+    /* Set the mqtt_client thread to log errors */
+    thrd_set_log_mask(thrd_p, LOG_UPTO(DEBUG));
+
+    /* Start MQTT connection */
+    ret = mqtt_client_connect(&client);
+    if (ret != 0) {
+        std_printf(OSTR("Failed to connect to Broker: %d'\r\n"),
+                   ret);
+        return (ret);
+    }
+
+    /*
+     * We ping the broke to see if we have a connection.  This is not
+     * required, just a sanity check.
+     */
+    ret = mqtt_client_ping(&client);
+    if (ret != 0) {
+        std_printf(OSTR("Failed to ping Broker: %d'\r\n"),
+                   ret);
+        return (ret);
+    }
+
+    return (0);
+}
+
+static void publish_connected(void)
+{
+    struct mqtt_application_message_t pub;
+    int ret;
+
+    pub.topic.buf_p = "simba/test/connected";
+    pub.topic.size = strlen(pub.topic.buf_p);
+    pub.payload.buf_p = "true";
+    pub.payload.size = strlen(pub.payload.buf_p);
+    pub.qos = mqtt_qos_1_t;
+
+    ret = mqtt_client_publish(&client, &pub);
+    if (ret != 0) {
+        std_printf(OSTR("Failed to publish %s = %s: %d\r\n"),
+                   pub.topic.buf_p,
+                   pub.payload.buf_p,
+                   ret);
+    }
+}
+
+static void subscribe(void)
+{
+    struct mqtt_application_message_t sub;
+    int ret;
+
+    sub.topic.buf_p = "simba/test/sub0";
+    sub.topic.size = strlen(sub.topic.buf_p);
+    sub.qos = mqtt_qos_1_t;
+
+    std_printf(OSTR("Subscribing to %s\r\n"), sub.topic.buf_p);
+
+    ret = mqtt_client_subscribe(&client, &sub);
+    if (ret != 0) {
+        std_printf(OSTR("Failed to subscribe %s: %d\r\n"),
+                   sub.topic.buf_p,
+                   ret);
+    }
+}
+
+static void unsubscribe(void)
+{
+    struct mqtt_application_message_t unsub;
+    int ret;
+
+    unsub.topic.buf_p = "simba/test/sub0";
+    unsub.topic.size = strlen(unsub.topic.buf_p);
+
+    std_printf(OSTR("Unsubscribing from %s\r\n"), unsub.topic.buf_p);
+
+    ret = mqtt_client_unsubscribe(&client, &unsub);
+    if (ret != 0) {
+        std_printf(OSTR("Failed to unsubscribe %s: %d\r\n"),
+                   unsub.topic.buf_p,
+                   ret);
+    }
+}
+
+int main()
+{
+    int ret;
+
+    /* Initialization. */
+    sys_start();
+
+    /* Give serial console time to attach. */
+    thrd_sleep(1);
+
+    /* Connect and start operations. */
+    mqtt_init();
+
+    /* Publish a message */
+    publish_connected();
+
+    /* Subscribe to our single topic. */
+    subscribe();
+
+    while (message_count < 100) {
+        std_printf(OSTR("Got %d messages\r\n"), message_count);
+
+        /*
+         * Me must ensure we sent traffic periodically (at least every
+         * 10 seconds) to the MQTT broker, otherwise it will close the
+         * connection.
+         */
+        ret = mqtt_client_ping(&client);
+
+        if (ret != 0) {
+            std_printf(OSTR("Failed to ping Broker: %d\r\n"),
+                   ret);
+        }
+
+        thrd_sleep(5);
+    }
+
+    /* Unsbuscribe from our topic. */
+    unsubscribe();
+
+    return (0);
+}

--- a/src/inet/mqtt_client.c
+++ b/src/inet/mqtt_client.c
@@ -176,18 +176,18 @@ static int handle_control_connect(struct mqtt_client_t *self_p)
     }
 
     /* Write the variable header. */
-    buf[0] = 0;
-    buf[1] = 4;
-    buf[2] = 'M';
-    buf[3] = 'Q';
-    buf[4] = 'T';
-    buf[5] = 'T';
-    buf[6] = 4;
-    buf[7] = (CLEAN_SESSION);
-    buf[8] = 0;
-    buf[9] = 10;
-    buf[10] = 0;
-    buf[11] = 0;
+    buf[0] = 0;               /* Protocol Name - Length MSB */
+    buf[1] = 4;               /* Protocol Name - Length LSB */
+    buf[2] = 'M';             /* Protocol Name */
+    buf[3] = 'Q';             /* Protocol Name */
+    buf[4] = 'T';             /* Protocol Name */
+    buf[5] = 'T';             /* Protocol Name */
+    buf[6] = 4;               /* Protocol Level */
+    buf[7] = (CLEAN_SESSION); /* Connect Flags */
+    buf[8] = 0;               /* Keep Alive MSB */
+    buf[9] = 10;              /* Keep Alive LSB */
+    buf[10] = 0;              /* Payload - Length MSB */
+    buf[11] = 0;              /* Payload - Length LSB */
 
     if (chan_write(self_p->transport.out_p, &buf[0], 12) != 12) {
         return (-EIO);


### PR DESCRIPTION
The example is heavily based on tst/inet/mqtt_client_network/.

This change include the very basic initization in the mqtt_client
documentation page, as I think it makes the API more understandable.

More advanced features can be added to the example later, this should
get people going.

Closes eerimoq/simba#108.