### PR TITLE
Fix link to WEMOS D1 mini product page.

### DIFF
--- a/doc/boards/arduino_mega.rst
+++ b/doc/boards/arduino_mega.rst
@@ -73,7 +73,7 @@ Below is the memory usage of two applications:
 +==========================+===========+===========+
 | minimal-configuration    |      1734 |       278 |
 +--------------------------+-----------+-----------+
-| default-configuration    |     64282 |      3750 |
+| default-configuration    |     64836 |      3754 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -127,6 +127,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  0                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -223,6 +225,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -544,6 +548,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -639,6 +645,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/arduino_nano.rst
+++ b/doc/boards/arduino_nano.rst
@@ -72,7 +72,7 @@ Below is the memory usage of two applications:
 +==========================+===========+===========+
 | minimal-configuration    |      1548 |       278 |
 +--------------------------+-----------+-----------+
-| default-configuration    |     13168 |       801 |
+| default-configuration    |     13238 |       805 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -126,6 +126,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  0                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -222,6 +224,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  16                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -543,6 +547,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -638,6 +644,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/arduino_pro_micro.rst
+++ b/doc/boards/arduino_pro_micro.rst
@@ -72,9 +72,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |      6472 |       519 |
+| minimal-configuration    |      6542 |       519 |
 +--------------------------+-----------+-----------+
-| default-configuration    |     14932 |       930 |
+| default-configuration    |     15002 |       934 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -128,6 +128,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  0                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -224,6 +226,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  16                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -545,6 +549,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -640,6 +646,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/arduino_uno.rst
+++ b/doc/boards/arduino_uno.rst
@@ -72,7 +72,7 @@ Below is the memory usage of two applications:
 +==========================+===========+===========+
 | minimal-configuration    |      1548 |       278 |
 +--------------------------+-----------+-----------+
-| default-configuration    |     13168 |       801 |
+| default-configuration    |     13238 |       805 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -126,6 +126,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  0                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -222,6 +224,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  16                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -543,6 +547,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -638,6 +644,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/esp01.rst
+++ b/doc/boards/esp01.rst
@@ -71,9 +71,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |    265804 |     33992 |
+| minimal-configuration    |    265808 |     33992 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    311796 |     46852 |
+| default-configuration    |    311948 |     46892 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -127,6 +127,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -223,6 +225,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -546,6 +550,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -641,6 +647,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/esp12e.rst
+++ b/doc/boards/esp12e.rst
@@ -71,9 +71,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |    265804 |     33992 |
+| minimal-configuration    |    265808 |     33992 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    311912 |     46880 |
+| default-configuration    |    312064 |     46928 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -127,6 +127,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -223,6 +225,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -546,6 +550,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -641,6 +647,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/esp32_devkitc.rst
+++ b/doc/boards/esp32_devkitc.rst
@@ -69,9 +69,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |     91356 |      8636 |
+| minimal-configuration    |     91360 |      8636 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    355004 |     83384 |
+| default-configuration    |    356496 |     83380 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -125,6 +125,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -221,6 +223,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -544,6 +548,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -639,6 +645,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/huzzah.rst
+++ b/doc/boards/huzzah.rst
@@ -71,9 +71,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |    265804 |     33992 |
+| minimal-configuration    |    265808 |     33992 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    311088 |     46336 |
+| default-configuration    |    311240 |     46368 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -127,6 +127,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -223,6 +225,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -546,6 +550,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -641,6 +647,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/linux.rst
+++ b/doc/boards/linux.rst
@@ -72,9 +72,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |    144940 |    318744 |
+| minimal-configuration    |    148148 |    319704 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    383483 |    473072 |
+| default-configuration    |    388523 |    473968 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -128,6 +128,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -224,6 +226,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -367,7 +371,7 @@ Default Standard Library configuration.
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_SD_                                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
-|  CONFIG_SETTINGS_AREA_SIZE_                            |  256                                                |
+|  CONFIG_SETTINGS_AREA_SIZE_                            |  1028                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_SETTINGS_BLOB_                                 |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -545,6 +549,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -640,6 +646,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/maple_esp32.rst
+++ b/doc/boards/maple_esp32.rst
@@ -69,9 +69,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |     91356 |      8636 |
+| minimal-configuration    |     91360 |      8636 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    355004 |     83384 |
+| default-configuration    |    356496 |     83380 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -125,6 +125,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -221,6 +223,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -544,6 +548,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -639,6 +645,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/nano32.rst
+++ b/doc/boards/nano32.rst
@@ -69,9 +69,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |     91356 |      8636 |
+| minimal-configuration    |     91360 |      8636 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    354996 |     83384 |
+| default-configuration    |    356488 |     83380 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -125,6 +125,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -221,6 +223,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -544,6 +548,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -639,6 +645,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/nodemcu.rst
+++ b/doc/boards/nodemcu.rst
@@ -71,9 +71,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |    265804 |     33992 |
+| minimal-configuration    |    265808 |     33992 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    311952 |     46868 |
+| default-configuration    |    312104 |     46908 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -127,6 +127,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -223,6 +225,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -546,6 +550,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -641,6 +647,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/photon.rst
+++ b/doc/boards/photon.rst
@@ -60,7 +60,7 @@ Below is the memory usage of two applications:
 +==========================+===========+===========+
 | minimal-configuration    |      4204 |      1672 |
 +--------------------------+-----------+-----------+
-| default-configuration    |     81768 |      5986 |
+| default-configuration    |     83048 |      5982 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -114,6 +114,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -210,6 +212,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -533,6 +537,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -628,6 +634,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/stm32f3discovery.rst
+++ b/doc/boards/stm32f3discovery.rst
@@ -60,7 +60,7 @@ Below is the memory usage of two applications:
 +==========================+===========+===========+
 | minimal-configuration    |      4352 |      1672 |
 +--------------------------+-----------+-----------+
-| default-configuration    |     80384 |      5490 |
+| default-configuration    |     81664 |      5486 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -114,6 +114,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -210,6 +212,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -533,6 +537,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -628,6 +634,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/stm32vldiscovery.rst
+++ b/doc/boards/stm32vldiscovery.rst
@@ -60,7 +60,7 @@ Below is the memory usage of two applications:
 +==========================+===========+===========+
 | minimal-configuration    |      4352 |      1672 |
 +--------------------------+-----------+-----------+
-| default-configuration    |     81664 |      5986 |
+| default-configuration    |     82944 |      5982 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -114,6 +114,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -210,6 +212,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -533,6 +537,8 @@ Mcu
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
 
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
+
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
 .. _CONFIG_FS_CMD_DS18B20_LIST: ../user-guide/configuration.html#c.CONFIG_FS_CMD_DS18B20_LIST
@@ -628,6 +634,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/boards/wemos_d1_mini.rst
+++ b/doc/boards/wemos_d1_mini.rst
@@ -71,9 +71,9 @@ Below is the memory usage of two applications:
 +--------------------------+-----------+-----------+
 | Application              | Flash     | RAM       |
 +==========================+===========+===========+
-| minimal-configuration    |    265804 |     33992 |
+| minimal-configuration    |    265808 |     33992 |
 +--------------------------+-----------+-----------+
-| default-configuration    |    311124 |     46356 |
+| default-configuration    |    311276 |     46396 |
 +--------------------------+-----------+-----------+
 
 Default configuration
@@ -127,6 +127,8 @@ Default Standard Library configuration.
 |  CONFIG_FILESYSTEM_GENERIC_                            |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLASH_                                         |  1                                                  |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_FLASH_DEVICE_SEMAPHORE_                        |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_FLOAT_                                         |  1                                                  |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -223,6 +225,8 @@ Default Standard Library configuration.
 |  CONFIG_FS_PATH_MAX_                                   |  64                                                 |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_EXPECT_BUFFER_SIZE_                    |  512                                                |
++--------------------------------------------------------+-----------------------------------------------------+
+|  CONFIG_HARNESS_HEAP_MAX_                              |  2048                                               |
 +--------------------------------------------------------+-----------------------------------------------------+
 |  CONFIG_HARNESS_SLEEP_MS_                              |  300                                                |
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -495,7 +499,7 @@ Default Standard Library configuration.
 Homepage
 --------
 
-https://www.wemos.cc/product/d1-mini.html
+https://wiki.wemos.cc/products:d1:d1_mini
 
 Mcu
 ---
@@ -545,6 +549,8 @@ Mcu
 .. _CONFIG_FILESYSTEM_GENERIC: ../user-guide/configuration.html#c.CONFIG_FILESYSTEM_GENERIC
 
 .. _CONFIG_FLASH: ../user-guide/configuration.html#c.CONFIG_FLASH
+
+.. _CONFIG_FLASH_DEVICE_SEMAPHORE: ../user-guide/configuration.html#c.CONFIG_FLASH_DEVICE_SEMAPHORE
 
 .. _CONFIG_FLOAT: ../user-guide/configuration.html#c.CONFIG_FLOAT
 
@@ -641,6 +647,8 @@ Mcu
 .. _CONFIG_FS_PATH_MAX: ../user-guide/configuration.html#c.CONFIG_FS_PATH_MAX
 
 .. _CONFIG_HARNESS_EXPECT_BUFFER_SIZE: ../user-guide/configuration.html#c.CONFIG_HARNESS_EXPECT_BUFFER_SIZE
+
+.. _CONFIG_HARNESS_HEAP_MAX: ../user-guide/configuration.html#c.CONFIG_HARNESS_HEAP_MAX
 
 .. _CONFIG_HARNESS_SLEEP_MS: ../user-guide/configuration.html#c.CONFIG_HARNESS_SLEEP_MS
 

--- a/doc/developer-guide/testing-suites.rst
+++ b/doc/developer-guide/testing-suites.rst
@@ -137,6 +137,7 @@ Linux
 - :github-blob:`text/std<tst/text/std/main.c>`
 - :github-blob:`text/re<tst/text/re/main.c>`
 - :github-blob:`debug/log<tst/debug/log/main.c>`
+- :github-blob:`debug/harness<tst/debug/harness/main.c>`
 - :github-blob:`oam/nvm<tst/oam/nvm/main.c>`
 - :github-blob:`oam/service<tst/oam/service/main.c>`
 - :github-blob:`oam/settings<tst/oam/settings/main.c>`

--- a/src/boards/wemos_d1_mini/board.mk
+++ b/src/boards/wemos_d1_mini/board.mk
@@ -34,7 +34,7 @@ SRC += $(SIMBA_ROOT)/src/boards/wemos_d1_mini/board.c
 LINKER_SCRIPT ?= simba.flash.4m.ld
 ESP_FLASH_SIZE = 4M
 
-BOARD_HOMEPAGE = "https://www.wemos.cc/product/d1-mini.html"
+BOARD_HOMEPAGE = "https://wiki.wemos.cc/products:d1:d1_mini"
 BOARD_PINOUT = "wemos-d1-mini-pinout.jpg"
 BOARD_DESC = "WEMOS D1 mini"
 


### PR DESCRIPTION
Regenerate docs so new product page link is picked up.