### PR TITLE
ESP32 : eeprom_i2c over i2c_soft; i2c_soft fixes

### DIFF
--- a/src/config_default.h
+++ b/src/config_default.h
@@ -142,6 +142,7 @@
 #    define PORT_HAS_RANDOM
 #    define PORT_HAS_WS2812
 #    define PORT_HAS_EEPROM_SOFT
+#    define PORT_HAS_EEPROM_I2C
 #endif
 
 #if defined(FAMILY_STM32F1)

--- a/src/drivers/eeprom_i2c.c
+++ b/src/drivers/eeprom_i2c.c
@@ -1,0 +1,135 @@
+#include "simba.h"
+#if CONFIG_PUMBAA_CLASS_I2C_SOFT == 1
+struct i2c_soft_driver_t i2c;
+
+int eeprom_i2c_init(struct i2c_soft_driver_t *self_p,
+                  struct pin_device_t *scl_dev_p,
+                  struct pin_device_t *sda_dev_p,
+                  long baudrate,
+                  long max_clock_stretching_us,
+                  long clock_stretching_sleep_us)
+{
+    return i2c_soft_init(self_p,scl_dev_p,sda_dev_p,baudrate,max_clock_stretching_us,clock_stretching_sleep_us);
+}
+
+
+
+static int start_cond(struct i2c_soft_driver_t *self_p)
+{
+    return i2c_soft_start_cond(self_p);
+
+}
+
+
+static int stop_cond(struct i2c_soft_driver_t *self_p)
+{
+    return i2c_soft_stop_cond(self_p);
+
+}
+
+static int write_byte(struct i2c_soft_driver_t *self_p,
+                      uint8_t byte, int ACK)
+{
+    return i2c_soft_write_byte(self_p,byte,ACK);
+}
+
+/**
+ * Read a byte from I2C bus.
+ */
+static int read_byte(struct i2c_soft_driver_t *self_p,
+                     uint8_t *byte_p, uint8_t ACK)
+{
+    return i2c_soft_read_byte(self_p,byte_p,ACK);
+}
+
+
+#define EEPROM_PAGE_DIM 32
+#define EEPROM_BYTE_READ   0b10100001
+#define EEPROM_BYTE_WRITE  0b10100000
+
+
+#define CHK(x) do { \
+  int retval = (x); \
+  if (retval != 0) { \
+    fprintf(stderr, "Eeprom error: %s returned %d at %s:%d", #x, retval, __FILE__, __LINE__); \
+    stop_cond(&i2c); \
+    return -1 ; \
+  } \
+} while (0)
+int eeprom_i2c_write_buf(struct i2c_soft_driver_t *self_p,int device, int addr, char *buf, int size)
+{
+    int i; 
+
+    for(i = addr; i < addr + size ; i ++ ) 
+    {
+        if( i == addr || i % EEPROM_PAGE_DIM == 0 )
+        {
+            //new page 
+            if( i > addr ) 
+            {
+                //stop for previous stream 
+                CHK(stop_cond(self_p));
+            }
+            //poll the write eeprom write cycle 
+            while(1)
+            {
+                if(start_cond(self_p) == 0 
+                   && write_byte(self_p, EEPROM_BYTE_WRITE | (device << 1),1 ) == 0)
+                    break ; 
+            }
+            CHK(write_byte(self_p, (uint8_t)(i >> 8) & 255,1));
+            CHK(write_byte(self_p, (uint8_t)i & 255,1));
+        }
+        //write in the next byte of the current page 
+        CHK(write_byte(self_p, buf[i - addr], 1));
+        
+    }
+    CHK(stop_cond(self_p));
+    return 0; 
+    
+}
+int eeprom_i2c_read_buf(struct i2c_soft_driver_t *self_p, int device, int addr, char *buf, int size)
+{
+    int i;
+    for(i = addr ; i < addr + size ; i ++ ) 
+    {
+        if( i == addr || i % EEPROM_PAGE_DIM == 0 )
+        {
+            if(i > addr ) 
+            {
+                
+            }
+            if( i == addr )
+            {
+                //poll the eeprom write cycle 
+                while(1) 
+                {
+                    if(start_cond(self_p) == 0 
+                        && write_byte(self_p, EEPROM_BYTE_WRITE | (device << 1), 1) == 0)
+                        break; 
+                }
+                CHK(write_byte(self_p, (uint8_t)(i >> 8) & 255, 1) );
+                CHK(write_byte(self_p, (uint8_t)i & 255,1));
+                CHK(start_cond(self_p));
+                CHK(write_byte(self_p, EEPROM_BYTE_READ | (device << 1),1));
+            }
+        }
+        if( i == addr + size - 1 ) 
+        {
+            //read, no ack 
+            CHK(read_byte(self_p, (uint8_t *) &buf[i - addr], 0));
+        }
+        else 
+        {
+            //sequential read, ack 
+            CHK(read_byte(self_p, (uint8_t *) &buf[i - addr], 1));
+        }
+    }
+    CHK(stop_cond(self_p));
+    return 0;
+}
+int eeprom_i2c_module_init()
+{
+    return 0;
+}
+#endif

--- a/src/drivers/eeprom_i2c.h
+++ b/src/drivers/eeprom_i2c.h
@@ -1,0 +1,10 @@
+#include "simba.h"
+int eeprom_i2c_write_buf(struct i2c_soft_driver_t *self_p,int device, int addr, char *buf, int size);
+int eeprom_i2c_read_buf (struct i2c_soft_driver_t *self_p,int device, int addr, char *buf, int size);
+int eeprom_i2c_init(struct i2c_soft_driver_t *self_p,
+                  struct pin_device_t *scl_dev_p,
+                  struct pin_device_t *sda_dev_p,
+                  long baudrate,
+                  long max_clock_stretching_us,
+                  long clock_stretching_sleep_us);
+int eeprom_i2c_module_init();

--- a/src/drivers/i2c_soft.h
+++ b/src/drivers/i2c_soft.h
@@ -135,7 +135,11 @@ ssize_t i2c_soft_write(struct i2c_soft_driver_t *self_p,
  * @return true(1) if a slave responded to given address, otherwise
  *         false(0) or negative error code.
  */
-int i2c_soft_scan(struct i2c_soft_driver_t *self_p,
-                  int address);
+int i2c_soft_scan(struct i2c_soft_driver_t *self_p,int address);
 
+
+int i2c_soft_write_byte(struct i2c_soft_driver_t *self_p,uint8_t byte,    uint8_t ACK);
+int i2c_soft_read_byte (struct i2c_soft_driver_t *self_p,uint8_t *byte_p, uint8_t ACK);
+int i2c_soft_stop_cond(struct i2c_soft_driver_t *self_p);                     
+int i2c_soft_start_cond(struct i2c_soft_driver_t *self_p);                     
 #endif

--- a/src/simba.h
+++ b/src/simba.h
@@ -233,6 +233,10 @@ extern "C" {
 #ifdef PORT_HAS_EEPROM_SOFT
 #    include "drivers/eeprom_soft.h"
 #endif
+#ifdef PORT_HAS_EEPROM_I2C
+#   include "drivers/eeprom_i2c.h"
+#endif 
+
 
 #include "inet/isotp.h"
 

--- a/src/simba.mk
+++ b/src/simba.mk
@@ -227,7 +227,8 @@ DRIVERS_SRC ?= \
 	random.c \
 	spi.c \
 	uart.c \
-	ws2812.c
+	ws2812.c \
+    eeprom_i2c.c 
 endif
 
 ifeq ($(FAMILY),stm32f1)


### PR DESCRIPTION
i2c_software implementation fixes ( fixed some missing delays ) 

added support for writing/reading bytes with NACK in i2c_software ( needed in eeprom_i2c protocol) 
exposed i2c_software write_byte, read_byte, start_cond, stop_cond

implemented eeprom_i2c over i2c_software, followed http://www.farnell.com/datasheets/1955909.pdf?_ga=2.96995549.354645081.1496223749-2116121241.1488793071

eeprom_i2c implementation supports reading/writing pages into eeprom at specific addresses for a given device. 8 eeprom_i2c devices can be connected  simultaneously at the same i2c.




also wrote wrapper in pumbaa for eeprom_i2c 
(https://github.com/LupascuAndrei/dump/blob/master/pumbaa/eeprom/class_eeprom.c ) 
will integrate it into pumbaa once this pull request is accepted
(tested example of how it will look like inside pumbaa : 
https://github.com/LupascuAndrei/dump/blob/master/pumbaa/eeprom/pumbaa_example.py 
)

I hope i didn't miss any modification when integrating into simba; ( i'm using an outdated version of simba)