### PR TITLE
Change mqtt_client keep alive from 10s to 5m.

### DIFF
--- a/src/inet/mqtt_client.c
+++ b/src/inet/mqtt_client.c
@@ -82,6 +82,9 @@ static const char *message_fmt[] = {
     "forbidden"
 };
 
+//! Interval required between MQTT packets.
+#define KEEP_ALIVE 300
+
 /**
  * Write the fixed header of the MQTT message to the server.
  */
@@ -176,18 +179,18 @@ static int handle_control_connect(struct mqtt_client_t *self_p)
     }
 
     /* Write the variable header. */
-    buf[0] = 0;               /* Protocol Name - Length MSB */
-    buf[1] = 4;               /* Protocol Name - Length LSB */
-    buf[2] = 'M';             /* Protocol Name */
-    buf[3] = 'Q';             /* Protocol Name */
-    buf[4] = 'T';             /* Protocol Name */
-    buf[5] = 'T';             /* Protocol Name */
-    buf[6] = 4;               /* Protocol Level */
-    buf[7] = (CLEAN_SESSION); /* Connect Flags */
-    buf[8] = 0;               /* Keep Alive MSB */
-    buf[9] = 10;              /* Keep Alive LSB */
-    buf[10] = 0;              /* Payload - Length MSB */
-    buf[11] = 0;              /* Payload - Length LSB */
+    buf[0] = 0;                          /* Protocol Name - Length MSB */
+    buf[1] = 4;                          /* Protocol Name - Length LSB */
+    buf[2] = 'M';                        /* Protocol Name */
+    buf[3] = 'Q';                        /* Protocol Name */
+    buf[4] = 'T';                        /* Protocol Name */
+    buf[5] = 'T';                        /* Protocol Name */
+    buf[6] = 4;                          /* Protocol Level */
+    buf[7] = (CLEAN_SESSION);            /* Connect Flags */
+    buf[8] = ((KEEP_ALIVE) >> 8) & 0xff; /* Keep Alive MSB */
+    buf[9] = (KEEP_ALIVE) & 0xff;        /* Keep Alive LSB */
+    buf[10] = 0;                         /* Payload - Length MSB */
+    buf[11] = 0;                         /* Payload - Length LSB */
 
     if (chan_write(self_p->transport.out_p, &buf[0], 12) != 12) {
         return (-EIO);

--- a/tst/inet/mqtt_client/main.c
+++ b/tst/inet/mqtt_client/main.c
@@ -151,25 +151,25 @@ static int test_connect(struct harness_t *harness_p)
     BTASSERT(queue_write(&qserverin, &message, sizeof(message)) == sizeof(message));
 
     /* Connect. */
-    BTASSERT(mqtt_client_connect(&client) == 0);
+    BTASSERTI(mqtt_client_connect(&client), ==, 0);
 
-    BTASSERT(queue_read(&qserverout, buf, 2) == 2);
-    BTASSERT(buf[0] == 0x10);
-    BTASSERT(buf[1] == 12);
+    BTASSERTI(queue_read(&qserverout, buf, 2), ==, 2);
+    BTASSERTI(buf[0], ==, 0x10);
+    BTASSERTI(buf[1], ==, 12);
 
-    BTASSERT(queue_read(&qserverout, buf, 12) == 12);
-    BTASSERT(buf[0] == 0);
-    BTASSERT(buf[1] == 4);
-    BTASSERT(buf[2] == 'M');
-    BTASSERT(buf[3] == 'Q');
-    BTASSERT(buf[4] == 'T');
-    BTASSERT(buf[5] == 'T');
-    BTASSERT(buf[6] == 4);
-    BTASSERT(buf[7] == 0x02);
-    BTASSERT(buf[8] == 0);
-    BTASSERT(buf[9] == 10);
-    BTASSERT(buf[10] == 0);
-    BTASSERT(buf[11] == 0);
+    BTASSERTI(queue_read(&qserverout, buf, 12), ==, 12);
+    BTASSERTI(buf[0], ==, 0);
+    BTASSERTI(buf[1], ==, 4);
+    BTASSERTI(buf[2], ==, 'M');
+    BTASSERTI(buf[3], ==, 'Q');
+    BTASSERTI(buf[4], ==, 'T');
+    BTASSERTI(buf[5], ==, 'T');
+    BTASSERTI(buf[6], ==, 4);
+    BTASSERTI(buf[7], ==, 0x02);
+    BTASSERTI(buf[8], ==, 1);
+    BTASSERTI(buf[9], ==, 0x2c);
+    BTASSERTI(buf[10], ==, 0);
+    BTASSERTI(buf[11], ==, 0);
 
     return (0);
 }


### PR DESCRIPTION
In the current mqtt_client, when the keep alive expires there is no
way to reconnect, so there is no advantage in a short keep alive
period as mqtt_client just silently stops working at that point.

This is mostly a bandaid until larger rework of connection options is
done for #109, #110 and #113. Since that rework is required, this
change is intentionally kept simple and does not allow user override
of the keep alive interval.

While here use BTASSERTI in a number of cases to make test output more
usable.

This was tested using mqtt_client, and mqtt_client_network against a
real MQTT broker (Mosquitto).