### PR TITLE
Platformio: get application name from APP_NAME environment variable.

### DIFF
--- a/make/platformio.sconscript
+++ b/make/platformio.sconscript
@@ -3961,7 +3961,7 @@ def set_default_values(env):
             env.Append(VERSION=f.read().strip())
 
     if "NAME" not in env:
-        env.Append(NAME="app_name")
+        env.Append(NAME=os.getenv("APP_NAME", "app_name"))
 
 
 def setup_mcu_esp(env, linker_script, flash_size_map):

--- a/make/platformio/platformio.py
+++ b/make/platformio/platformio.py
@@ -108,7 +108,7 @@ def set_default_values(env):
             env.Append(VERSION=f.read().strip())
 
     if "NAME" not in env:
-        env.Append(NAME="app_name")
+        env.Append(NAME=os.getenv("APP_NAME", "app_name"))
 
 
 def setup_mcu_esp(env, linker_script, flash_size_map):


### PR DESCRIPTION
See issue #131 

With platformio, solves the problem to set the application name passed as an argument to simbagen.py script. 

It uses the environment variable _APP_NAME_ in [platformio.sconscript](https://github.com/eerimoq/simba/blob/master/make/platformio.sconscript#L3964) (default is _app_name_), so with this patch application name can be set with:

`APP_NAME='MyApp' pio run`

or 

```
export APP_NAME='MyApp'
pio run
```