### PR TITLE
Add settings module support for PlatformIO

### DIFF
--- a/bin/simbagen.py
+++ b/bin/simbagen.py
@@ -168,13 +168,12 @@ class Settings(object):
         self.endianess = endianess
         self.settings = OrderedDict()
 
-        if not filename:
+        if filename is None:
             return
 
         settings_parser = ConfigParser()
         if not settings_parser.read(filename):
-            print("Failed to load config file from {}".format(filename))
-            return
+            sys.exit("Failed to load config file '{}'.".format(filename))
 
         addresses = []
         sizes = {}

--- a/bin/simbagen.py
+++ b/bin/simbagen.py
@@ -168,11 +168,13 @@ class Settings(object):
         self.endianess = endianess
         self.settings = OrderedDict()
 
-        if filename is None:
+        if not filename:
             return
 
         settings_parser = ConfigParser()
-        settings_parser.read(filename)
+        if not settings_parser.read(filename):
+            print("Failed to load config file from {}".format(filename))
+            return
 
         addresses = []
         sizes = {}

--- a/make/platformio.sconscript
+++ b/make/platformio.sconscript
@@ -29,7 +29,7 @@
 #
 
 import os
-from os.path import join
+from os.path import join, isabs, isfile, normpath
 import subprocess
 import shutil
 
@@ -4260,6 +4260,14 @@ source_files = []
 for src in env.LookupSources(variant_dir, src_dir, True, src_filter):
     source_files.append(env.Object(src))
 
+# get settings file path
+settings_ini_path = next(
+                    (x[1] for x in env["CPPDEFINES"]
+                          if len(x) > 1 and x[0] == "SETTINGS_INI"),
+                    "")
+if settings_ini_path and not (isabs(settings_ini_path)):
+    settings_ini_path = normpath(join(env['PROJECT_DIR'], settings_ini_path))
+
 # Command to generate simba_gen.c
 env.Command(SIMBA_GEN_C,
             source_files,
@@ -4271,7 +4279,8 @@ env.Command(SIMBA_GEN_C,
              '--board "$BOARD_DESC" '
              '--mcu "$MCU_DESC" '
              '--endianess little '
-             '--eeprom-soft-chunk-size 2048 '))
+             '--eeprom-soft-chunk-size 2048 '
+             '--settings "{}" '.format(settings_ini_path)))
 source_files.append(SIMBA_GEN_C)
 
 lib = env.Library(target=join("$BUILD_DIR", "SimbaFramework"), source=source_files)

--- a/make/platformio.sconscript
+++ b/make/platformio.sconscript
@@ -4278,7 +4278,7 @@ if settings_ini is not None:
     try:
         settings_ini = str(env.File(settings_ini.decode('base64'), 
                                     env['PROJECT_DIR']))
-    except Exception, e:
+    except Exception as e:
         sys.exit("Failed to load config file. " + str(e))
     gen_command_action += '--settings "{}" '.format(str(settings_ini))
 

--- a/make/platformio.sconscript
+++ b/make/platformio.sconscript
@@ -4273,7 +4273,7 @@ gen_command_action = ('"$PYTHONEXE" "$PLATFORMFW_DIR/bin/simbagen.py" '
              '--eeprom-soft-chunk-size 2048 ')
 
 # get settings file path
-settings_ini = ARGUMENTS.get('SETTINGS_PATH')
+settings_ini = ARGUMENTS.get('SETTINGS_INI')
 if settings_ini is not None:
     try:
         settings_ini = str(env.File(settings_ini.decode('base64'), 

--- a/make/platformio.sconscript
+++ b/make/platformio.sconscript
@@ -28,8 +28,9 @@
 # This file is part of the Simba project.
 #
 
+import sys
 import os
-from os.path import join, exists
+from os.path import join, isfile
 import subprocess
 import shutil
 
@@ -4260,18 +4261,8 @@ source_files = []
 for src in env.LookupSources(variant_dir, src_dir, True, src_filter):
     source_files.append(env.Object(src))
 
-# get settings file path
-settings_ini_path = ARGUMENTS.get('SETTINGS_PATH', "").decode('base64')
-if settings_ini_path:
-    settings_ini_file = env.File(settings_ini_path, env['PROJECT_DIR'])
-    settings_ini_path = str(settings_ini_file)
-    if not exists(settings_ini_path):
-        settings_ini_path = ""
-
-# Command to generate simba_gen.c
-gen_command = env.Command(SIMBA_GEN_C,
-            source_files,
-            ('"$PYTHONEXE" "$PLATFORMFW_DIR/bin/simbagen.py" '
+# action string to generate simba_gen.c
+gen_command_action = ('"$PYTHONEXE" "$PLATFORMFW_DIR/bin/simbagen.py" '
              '--output-directory "$BUILD_DIR/SimbaFramework" '
              'source '
              '--name "$NAME" '
@@ -4279,12 +4270,26 @@ gen_command = env.Command(SIMBA_GEN_C,
              '--board "$BOARD_DESC" '
              '--mcu "$MCU_DESC" '
              '--endianess little '
-             '--eeprom-soft-chunk-size 2048 '
-             '--settings "{}" '.format(settings_ini_path)))
+             '--eeprom-soft-chunk-size 2048 ')
+
+# get settings file path
+settings_ini = ARGUMENTS.get('SETTINGS_PATH')
+if settings_ini is not None:
+    try:
+        settings_ini = str(env.File(settings_ini.decode('base64'), 
+                                    env['PROJECT_DIR']))
+    except Exception, e:
+        sys.exit("Failed to load config file. " + str(e))
+    gen_command_action += '--settings "{}" '.format(str(settings_ini))
+
+# Command to generate simba_gen.c
+gen_command = env.Command(SIMBA_GEN_C,
+            source_files,
+            gen_command_action)
 source_files.append(SIMBA_GEN_C)
 
-if settings_ini_path:
-    env.Depends(gen_command, settings_ini_path)
+if settings_ini and isfile(settings_ini):
+    env.Depends(gen_command, settings_ini)
 
 lib = env.Library(target=join("$BUILD_DIR", "SimbaFramework"), source=source_files)
 

--- a/make/platformio.sconscript
+++ b/make/platformio.sconscript
@@ -29,7 +29,7 @@
 #
 
 import os
-from os.path import join, isabs, isfile, normpath
+from os.path import join, exists
 import subprocess
 import shutil
 
@@ -4261,15 +4261,15 @@ for src in env.LookupSources(variant_dir, src_dir, True, src_filter):
     source_files.append(env.Object(src))
 
 # get settings file path
-settings_ini_path = next(
-                    (x[1] for x in env["CPPDEFINES"]
-                          if len(x) > 1 and x[0] == "SETTINGS_INI"),
-                    "")
-if settings_ini_path and not (isabs(settings_ini_path)):
-    settings_ini_path = normpath(join(env['PROJECT_DIR'], settings_ini_path))
+settings_ini_path = ARGUMENTS.get('SETTINGS_PATH', "").decode('base64')
+if settings_ini_path:
+    settings_ini_file = env.File(settings_ini_path, env['PROJECT_DIR'])
+    settings_ini_path = str(settings_ini_file)
+    if not exists(settings_ini_path):
+        settings_ini_path = ""
 
 # Command to generate simba_gen.c
-env.Command(SIMBA_GEN_C,
+gen_command = env.Command(SIMBA_GEN_C,
             source_files,
             ('"$PYTHONEXE" "$PLATFORMFW_DIR/bin/simbagen.py" '
              '--output-directory "$BUILD_DIR/SimbaFramework" '
@@ -4282,6 +4282,9 @@ env.Command(SIMBA_GEN_C,
              '--eeprom-soft-chunk-size 2048 '
              '--settings "{}" '.format(settings_ini_path)))
 source_files.append(SIMBA_GEN_C)
+
+if settings_ini_path:
+    env.Depends(gen_command, settings_ini_path)
 
 lib = env.Library(target=join("$BUILD_DIR", "SimbaFramework"), source=source_files)
 

--- a/make/platformio/platformio.py
+++ b/make/platformio/platformio.py
@@ -425,7 +425,7 @@ if settings_ini is not None:
     try:
         settings_ini = str(env.File(settings_ini.decode('base64'), 
                                     env['PROJECT_DIR']))
-    except Exception, e:
+    except Exception as e:
         sys.exit("Failed to load config file. " + str(e))
     gen_command_action += '--settings "{{}}" '.format(str(settings_ini))
 

--- a/make/platformio/platformio.py
+++ b/make/platformio/platformio.py
@@ -420,14 +420,14 @@ gen_command_action = ('"$PYTHONEXE" "$PLATFORMFW_DIR/bin/simbagen.py" '
              '--eeprom-soft-chunk-size 2048 ')
 
 # get settings file path
-settings_ini = ARGUMENTS.get('SETTINGS_PATH')
+settings_ini = ARGUMENTS.get('SETTINGS_INI')
 if settings_ini is not None:
     try:
         settings_ini = str(env.File(settings_ini.decode('base64'), 
                                     env['PROJECT_DIR']))
     except Exception, e:
         sys.exit("Failed to load config file. " + str(e))
-    gen_command_action += '--settings "{}" '.format(str(settings_ini))
+    gen_command_action += '--settings "{{}}" '.format(str(settings_ini))
 
 # Command to generate simba_gen.c
 gen_command = env.Command(SIMBA_GEN_C,

--- a/make/platformio/platformio.py
+++ b/make/platformio/platformio.py
@@ -47,8 +47,9 @@ PLATFORMIO_SCONSSCRIPT_FMT = """#
 # This file is part of the Simba project.
 #
 
+import sys
 import os
-from os.path import join
+from os.path import join, isfile
 import subprocess
 import shutil
 
@@ -407,10 +408,8 @@ source_files = []
 for src in env.LookupSources(variant_dir, src_dir, True, src_filter):
     source_files.append(env.Object(src))
 
-# Command to generate simba_gen.c
-env.Command(SIMBA_GEN_C,
-            source_files,
-            ('"$PYTHONEXE" "$PLATFORMFW_DIR/bin/simbagen.py" '
+# action string to generate simba_gen.c
+gen_command_action = ('"$PYTHONEXE" "$PLATFORMFW_DIR/bin/simbagen.py" '
              '--output-directory "$BUILD_DIR/SimbaFramework" '
              'source '
              '--name "$NAME" '
@@ -418,8 +417,26 @@ env.Command(SIMBA_GEN_C,
              '--board "$BOARD_DESC" '
              '--mcu "$MCU_DESC" '
              '--endianess little '
-             '--eeprom-soft-chunk-size 2048 '))
+             '--eeprom-soft-chunk-size 2048 ')
+
+# get settings file path
+settings_ini = ARGUMENTS.get('SETTINGS_PATH')
+if settings_ini is not None:
+    try:
+        settings_ini = str(env.File(settings_ini.decode('base64'), 
+                                    env['PROJECT_DIR']))
+    except Exception, e:
+        sys.exit("Failed to load config file. " + str(e))
+    gen_command_action += '--settings "{}" '.format(str(settings_ini))
+
+# Command to generate simba_gen.c
+gen_command = env.Command(SIMBA_GEN_C,
+            source_files,
+            gen_command_action)
 source_files.append(SIMBA_GEN_C)
+
+if settings_ini and isfile(settings_ini):
+    env.Depends(gen_command, settings_ini)
 
 lib = env.Library(target=join("$BUILD_DIR", "SimbaFramework"), source=source_files)
 


### PR DESCRIPTION
discussed [on forum](https://forum.simbaos.org/showthread.php?tid=17)

usage:
1. add valid *.ini file with settings
2. set relative or absolute path to this file in board's options, for example:
```
[env:esp12e]
settings_path = ../settings/12e.ini

[env:esp8285]
settings_path = ~/settings/8285.ini
```
