### PR TITLE
Set the prescaler from milliseconds in avr watchdog.

### DIFF
--- a/src/drivers/basic/watchdog.h
+++ b/src/drivers/basic/watchdog.h
@@ -54,7 +54,10 @@ int watchdog_module_init(void);
  * Start the watchdog with given timeout. Use `watchdog_kick()` to
  * periodically restart the timer.
  *
- * @param[in] timeout Watchdog timeout in milliseconds.
+ * @param[in] timeout Watchdog timeout in milliseconds. This value is usually
+ *                    adjusted to a next longer limit in milliseconds because
+ *                    it depends on a hardware prescaler register. Further
+ *                    info in your microcontroller reference manual.
  * @param[in] on_interrupt Function callback called when a watchdog
  *                         interrupt occurs. Not all MCU:s supports
  *                         this feature.

--- a/src/drivers/basic/watchdog.h
+++ b/src/drivers/basic/watchdog.h
@@ -54,10 +54,8 @@ int watchdog_module_init(void);
  * Start the watchdog with given timeout. Use `watchdog_kick()` to
  * periodically restart the timer.
  *
- * @param[in] timeout Watchdog timeout in milliseconds. This value is usually
- *                    adjusted to a next longer limit in milliseconds because
- *                    it depends on a hardware prescaler register. Further
- *                    info in your microcontroller reference manual.
+ * @param[in] timeout Watchdog timeout in milliseconds. The timeout is rounded
+ *                    up to the closest timeout the hardware supports.
  * @param[in] on_interrupt Function callback called when a watchdog
  *                         interrupt occurs. Not all MCU:s supports
  *                         this feature.

--- a/src/drivers/ports/avr/watchdog_port.i
+++ b/src/drivers/ports/avr/watchdog_port.i
@@ -38,21 +38,21 @@ int watchdog_port_start_ms(int timeout,
     /*
      * http://www.nongnu.org/avr-libc/user-manual/group__avr__watchdog.html
      *
-     * Possible timeout values are:
-     * 15ms => prescaler 0
-     * 30ms => prescaler 1
-     * 60ms => prescaler 2
-     * 120ms => prescaler 3
-     * 250ms => prescaler 4
-     * 500ms => prescaler 5
-     * 1s => prescaler 6
-     * 2s => prescaler 7
+     * Timeout value is approximated to:
+     *     < 16 ms    => prescaler 0 (~15 ms)
+     *     < 32 ms    => prescaler 1 (~30 ms)
+     *     < 64 ms    => prescaler 2 (~60 ms)
+     *     < 128 ms   => prescaler 3 (~120 ms)
+     *     < 256 ms   => prescaler 4 (~250 ms)
+     *     < 512 ms   => prescaler 5 (~500 ms)
+     *     < 1024 ms  => prescaler 6 (~1 s)
+     *     >= 1024 ms => prescaler 7 (~2 s)
      */
-    timeout /= 15;
+    timeout /= 16;
     prescaler = 0;
-    while ((1 << prescaler) < timeout) {
+    while (prescaler < 7) {
+        if ((1 << prescaler) > timeout) break;
         prescaler++;
-        if (prescaler == 7) break;
     }
 
     wdt_enable(prescaler);

--- a/src/drivers/ports/avr/watchdog_port.i
+++ b/src/drivers/ports/avr/watchdog_port.i
@@ -33,7 +33,29 @@
 int watchdog_port_start_ms(int timeout,
                            watchdog_isr_fn_t on_interrupt)
 {
-    wdt_enable(timeout);
+    uint8_t prescaler;
+
+    /*
+     * http://www.nongnu.org/avr-libc/user-manual/group__avr__watchdog.html
+     *
+     * Possible timeout values are:
+     * 15ms => prescaler 0
+     * 30ms => prescaler 1
+     * 60ms => prescaler 2
+     * 120ms => prescaler 3
+     * 250ms => prescaler 4
+     * 500ms => prescaler 5
+     * 1s => prescaler 6
+     * 2s => prescaler 7
+     */
+    timeout /= 15;
+    prescaler = 0;
+    while ((1 << prescaler) < timeout) {
+        prescaler++;
+        if (prescaler == 7) break;
+    }
+
+    wdt_enable(prescaler);
 
     return (0);
 }


### PR DESCRIPTION
Simba framework uses milliseconds to set the watchdog timeout. AVR uses a prescaler value.