### PR TITLE
mqtt_client: Add support for connection options.

### DIFF
--- a/doc/library-reference/inet/mqtt_client.rst
+++ b/doc/library-reference/inet/mqtt_client.rst
@@ -6,10 +6,6 @@
 
 MQTT is a publish-subscribe-based lightweight messaging protocol.
 
-.. note:: This driver only implements the MQTT protocol, not the
-          transport layer (normally TCP). That has to be set up using
-          channels.
-
 The driver works by running the processing code in a thread which
 communicate with the MQTT broker on one side using channels, and the
 application on the other side using queues.
@@ -17,6 +13,23 @@ application on the other side using queues.
 This means the application has to set up appropriate channels, which
 is already ready to communicate with the MQTT server, e.g. using TCP,
 and the thread running the MQTT client.
+
+MQTT Notes
+----------
+
+MQTT requires the client to send packets regularly, otherwise the
+broker will disconnect the client. Any packet from the client to the
+broker will fulfill the requirement, so a regular stream of publish
+messages will work or sending MQTT Ping packets as needed. The keep
+alive interval is set by the client on connect, and can be changed
+from the default in the mqtt_conn_options_t.
+
+.. note:: The current client does not gracefully handle the underlying
+          channel (e.g. TCP connection) to the broker disconnecting,
+          and requires complete restart of the MQTT client to recover.
+
+Basic MQTT client usage
+-----------------------
 
 Basic example of initializing MQTT over TCP (error checking left out
 for brevity).

--- a/examples/mqtt_client/main.c
+++ b/examples/mqtt_client/main.c
@@ -144,7 +144,7 @@ static int mqtt_init(void)
     thrd_set_log_mask(thrd_p, LOG_UPTO(DEBUG));
 
     /* Start MQTT connection. */
-    res = mqtt_client_connect(&client);
+    res = mqtt_client_connect(&client, NULL);
 
     if (res != 0) {
         std_printf(OSTR("Failed to connect to Broker: %d'\r\n"),

--- a/src/inet/mqtt_client.c
+++ b/src/inet/mqtt_client.c
@@ -52,6 +52,12 @@
 
 /** Connection flags. */
 #define CLEAN_SESSION   0x2
+#define WILL_FLAG       0x4
+#define WILL_QOS_1      0x8
+#define WILL_QOS_2      0x10
+#define WILL_RETAIN     0x20
+#define PASSWORD_FLAG   0x40
+#define USER_NAME_FLAG  0x80
 
 #define CONNECTION_ACCEPTED 0
 
@@ -62,6 +68,9 @@
 #define CONTROL_SUBSCRIBE      4
 #define CONTROL_UNSUBSCRIBE    5
 #define CONTROL_NONE           6
+
+//! Length of a MQTT CONNECT variable header.
+#define CONNECT_VAR_HDR_LEN   10
 
 static const char *message_fmt[] = {
     "forbidden",
@@ -82,8 +91,47 @@ static const char *message_fmt[] = {
     "forbidden"
 };
 
-//! Interval required between MQTT packets.
-#define KEEP_ALIVE 300
+/** Extract Most Significant Byte from a 16bit value. */
+#define MSB(b) ((b >> 8) & 0xff)
+
+/** Extract Least Significant Byte from a 16bit value. */
+#define LSB(b) (b & 0xff)
+
+/**
+ * Write a single variable length string with header to the server.
+ */
+static int write_mqtt_string(struct mqtt_client_t *self_p,
+                             struct mqtt_string_t *mqtt_string)
+{
+    int res;
+    uint8_t buf[2];
+
+    if (mqtt_string->size == 0 || mqtt_string->buf_p == NULL) {
+        return (-EINVAL);
+    }
+
+    if (mqtt_string->size > 0xffff) {
+        return (-EINVAL);
+    }
+
+    /* Write length header */
+    buf[0] = MSB(mqtt_string->size);
+    buf[1] = LSB(mqtt_string->size);
+
+    if (chan_write(self_p->transport.out_p, &buf[0], 2) != 2) {
+        return (-EIO);
+    }
+
+    res = chan_write(self_p->transport.out_p,
+                     mqtt_string->buf_p,
+                     mqtt_string->size);
+
+    if (res != mqtt_string->size) {
+        return (-EIO);
+    }
+
+    return (0);
+}
 
 /**
  * Write the fixed header of the MQTT message to the server.
@@ -170,32 +218,151 @@ static int read_fixed_header(struct mqtt_client_t *self_p,
  */
 static int handle_control_connect(struct mqtt_client_t *self_p)
 {
-    int res = 0;
-    uint8_t buf[12];
+    struct mqtt_conn_options_t *options_p;
+    struct mqtt_conn_options_t default_options;
+    int res = 0, payload_length = 0;
+    uint8_t buf[CONNECT_VAR_HDR_LEN], flags = 0;
+
+    /*
+     * Note: Each payload string requires a 2 byte length header, so
+     * that must be accounted for in the payload length hence "+ 2" a
+     * number of length calculations below.
+     */
+
+    if (queue_read(&self_p->control.in,
+                   &options_p,
+                   sizeof(options_p)) != sizeof(options_p)) {
+        return (-1);
+    }
+
+    if (options_p == NULL) {
+        options_p = &default_options;
+        memset(options_p, 0, sizeof(*options_p));
+    }
+
+    /*
+     * We currently do not support ressuming session, so force clean
+     * session.
+     */
+    flags = CLEAN_SESSION;
+
+    /*
+      * Be sure that 'will' topic and payload are both either set or
+      * unset.
+      */
+    if ((options_p->will.topic.size == 0) !=
+        (options_p->will.payload.size == 0)) {
+        return (-EINVAL);
+    }
+
+    /*
+     * As per MQTT-3.1.3-3 a Client ID is required, so if the user has
+     * not specified one, we set one.
+     *
+     * We should preferably set a random client id, but we don't
+     * currently have an way to get a random number on all platforms.
+     */
+    if (options_p->client_id.size == 0) {
+        options_p->client_id.buf_p = FSTR("simba_mqtt");
+        options_p->client_id.size = strlen(options_p->client_id.buf_p);
+    }
+
+    /*
+     * Calculate payload length first as we need to send length in
+     * CONNECT header. We also set flags as they are also in the
+     * header.
+     */
+    payload_length = options_p->client_id.size + 2;
+
+    if (options_p->will.topic.size > 0) {
+        flags |= WILL_FLAG;
+
+        if (options_p->will.qos == mqtt_qos_1_t) {
+            flags |= WILL_QOS_1;
+        } else if (options_p->will.qos == mqtt_qos_2_t) {
+            flags |= WILL_QOS_2;
+        }
+
+        payload_length += options_p->will.topic.size + 2;
+        payload_length += options_p->will.payload.size + 2;
+    }
+
+    if (options_p->user_name.size > 0) {
+        flags |= USER_NAME_FLAG;
+        payload_length += options_p->user_name.size + 2;
+    }
+
+    if (options_p->password.size > 0) {
+        flags |= PASSWORD_FLAG;
+        payload_length += options_p->password.size + 2;
+    }
+
+    if (options_p->keep_alive_s == 0) {
+        options_p->keep_alive_s = DEFAULT_KEEP_ALIVE_S;
+    }
 
     /* Write the fixed header. */
-    res = write_fixed_header(self_p, MQTT_CONNECT, 0, 12);
+    res = write_fixed_header(self_p,
+                             MQTT_CONNECT,
+                             0,
+                             CONNECT_VAR_HDR_LEN + payload_length);
 
     if (res != 0) {
         return (res);
     }
 
     /* Write the variable header. */
-    buf[0] = 0;                          /* Protocol Name - Length MSB */
-    buf[1] = 4;                          /* Protocol Name - Length LSB */
-    buf[2] = 'M';                        /* Protocol Name */
-    buf[3] = 'Q';                        /* Protocol Name */
-    buf[4] = 'T';                        /* Protocol Name */
-    buf[5] = 'T';                        /* Protocol Name */
-    buf[6] = 4;                          /* Protocol Level */
-    buf[7] = (CLEAN_SESSION);            /* Connect Flags */
-    buf[8] = ((KEEP_ALIVE) >> 8) & 0xff; /* Keep Alive MSB */
-    buf[9] = (KEEP_ALIVE) & 0xff;        /* Keep Alive LSB */
-    buf[10] = 0;                         /* Payload - Length MSB */
-    buf[11] = 0;                         /* Payload - Length LSB */
+    buf[0] = 0;                            /* Protocol Name - Length MSB */
+    buf[1] = 4;                            /* Protocol Name - Length LSB */
+    buf[2] = 'M';                          /* Protocol Name */
+    buf[3] = 'Q';                          /* Protocol Name */
+    buf[4] = 'T';                          /* Protocol Name */
+    buf[5] = 'T';                          /* Protocol Name */
+    buf[6] = 4;                            /* Protocol Level */
+    buf[7] = flags;                        /* Connect Flags */
+    buf[8] = MSB(options_p->keep_alive_s); /* Keep Alive MSB */
+    buf[9] = LSB(options_p->keep_alive_s); /* Keep Alive LSB */
 
-    if (chan_write(self_p->transport.out_p, &buf[0], 12) != 12) {
+    if (chan_write(self_p->transport.out_p, &buf[0], CONNECT_VAR_HDR_LEN)
+        != CONNECT_VAR_HDR_LEN) {
         return (-EIO);
+    }
+
+    /* Write paylaod string by string. */
+    res = write_mqtt_string(self_p, &options_p->client_id);
+
+    if (res != 0) {
+        return (res);
+    }
+
+    if (options_p->will.topic.size > 0) {
+        res = write_mqtt_string(self_p, &options_p->will.topic);
+
+        if (res != 0) {
+            return (res);
+        }
+
+        res = write_mqtt_string(self_p, &options_p->will.payload);
+
+        if (res != 0) {
+            return (res);
+        }
+    }
+
+    if (options_p->user_name.size > 0) {
+        res = write_mqtt_string(self_p, &options_p->user_name);
+
+        if (res != 0) {
+            return (res);
+        }
+    }
+
+    if (options_p->password.size > 0) {
+        res = write_mqtt_string(self_p, &options_p->password);
+
+        if (res != 0) {
+            return (res);
+        }
     }
 
     self_p->message.type = CONTROL_CONNECT;
@@ -847,11 +1014,15 @@ static int control_routine(struct mqtt_client_t *self_p,
     return (res);
 }
 
-int mqtt_client_connect(struct mqtt_client_t *self_p)
+int mqtt_client_connect(struct mqtt_client_t *self_p,
+                        struct mqtt_conn_options_t *options_p)
 {
     ASSERTN(self_p != NULL, EINVAL)
 
-    return (control_routine(self_p, CONTROL_CONNECT, NULL, 0));
+    return (control_routine(self_p,
+                            CONTROL_CONNECT,
+                            &options_p,
+                            sizeof(options_p)));
 }
 
 int mqtt_client_disconnect(struct mqtt_client_t *self_p)

--- a/src/inet/mqtt_client.c
+++ b/src/inet/mqtt_client.c
@@ -263,7 +263,7 @@ static int handle_control_connect(struct mqtt_client_t *self_p)
      * currently have an way to get a random number on all platforms.
      */
     if (options_p->client_id.size == 0) {
-        options_p->client_id.buf_p = FSTR("simba_mqtt");
+        options_p->client_id.buf_p = "simba_mqtt";
         options_p->client_id.size = strlen(options_p->client_id.buf_p);
     }
 

--- a/src/inet/mqtt_client.h
+++ b/src/inet/mqtt_client.h
@@ -33,6 +33,9 @@
 
 #include "simba.h"
 
+/** Default MQTT keep alive interval in seconds. */
+#define DEFAULT_KEEP_ALIVE_S 300
+
 /** Client states. */
 enum mqtt_client_state_t {
     mqtt_client_state_disconnected_t,
@@ -76,6 +79,14 @@ typedef int (*mqtt_on_error_t)(struct mqtt_client_t *client_p,
                                int error);
 
 /**
+ * An MQTT style length string.
+ */
+struct mqtt_string_t {
+    const void *buf_p;
+    size_t size;
+};
+
+/**
  * MQTT client.
  */
 struct mqtt_client_t {
@@ -102,15 +113,26 @@ struct mqtt_client_t {
  * MQTT application message.
  */
 struct mqtt_application_message_t {
-    struct {
-        const char *buf_p;
-        size_t size;
-    } topic;
-    struct {
-        const void *buf_p;
-        size_t size;
-    } payload;
+    struct mqtt_string_t topic;
+    struct mqtt_string_t payload;
     enum mqtt_qos_t qos;
+};
+
+/**
+ * MQTT Connection options.
+ */
+struct mqtt_conn_options_t {
+    /** Should be 1-23 [0-9a-zA-Z] characters as per [MQTT-3.1.3-5]. */
+    struct mqtt_string_t client_id;
+    /** Optional Last Will and Testament to be sent on unclean disconnect. */
+    struct mqtt_application_message_t will;
+    /** Optional user name for broker authentication. */
+    struct mqtt_string_t user_name;
+    /** Optional password for broker authentication. */
+    struct mqtt_string_t password;
+
+    /*! Keep alive interval in seconds. */
+    int keep_alive_s;
 };
 
 /**
@@ -149,10 +171,19 @@ void *mqtt_client_main(void *arg_p);
  * Establish a connection to the server.
  *
  * @param[in] self_p MQTT client.
+ * @param[in] options_p MQTT connection options. May be NULL. Pointer
+ *                      only need to be valid for the duration of the
+ *                      function call.
+ *
+ * @warning If options_p is set, all members of the struct not
+ *          explicitly used, must be set to zero.  It is suggested to
+ *          do this by calling memset(options_p, 0,
+ *          sizeof(*options_p)); before setting needed variables.
  *
  * @return zero(0) or negative error code.
  */
-int mqtt_client_connect(struct mqtt_client_t *self_p);
+int mqtt_client_connect(struct mqtt_client_t *self_p,
+                        struct mqtt_conn_options_t *options_p);
 
 /**
  * Disconnect from the server.

--- a/tst/inet/mqtt_client/main.c
+++ b/tst/inet/mqtt_client/main.c
@@ -150,15 +150,15 @@ static int test_connect(void)
     /* Setup */
     memset(&conn_options, 0, sizeof(conn_options));
     conn_options.keep_alive_s = 4242;
-    conn_options.client_id.buf_p = FSTR("cid");
+    conn_options.client_id.buf_p = "cid";
     conn_options.client_id.size = 3;
-    conn_options.will.topic.buf_p = FSTR("wtop");
+    conn_options.will.topic.buf_p = "wtop";
     conn_options.will.topic.size = 4;
-    conn_options.will.payload.buf_p = FSTR("wpay");
+    conn_options.will.payload.buf_p = "wpay";
     conn_options.will.payload.size = 4;
-    conn_options.user_name.buf_p = FSTR("john");
+    conn_options.user_name.buf_p = "john";
     conn_options.user_name.size = 4;
-    conn_options.password.buf_p = FSTR("secret");
+    conn_options.password.buf_p = "secret";
     conn_options.password.size = 6;
 
     /* Prepare the server to receive the connection message. */

--- a/tst/inet/mqtt_client/main.c
+++ b/tst/inet/mqtt_client/main.c
@@ -36,6 +36,7 @@ struct message_t {
 };
 
 static struct mqtt_client_t client;
+static struct mqtt_conn_options_t conn_options;
 static struct queue_t qout;
 static struct queue_t qin;
 static struct queue_t qserverout;
@@ -146,9 +147,23 @@ static int test_connect(void)
     struct message_t message;
     uint8_t buf[16];
 
+    /* Setup */
+    memset(&conn_options, 0, sizeof(conn_options));
+    conn_options.keep_alive_s = 4242;
+    conn_options.client_id.buf_p = FSTR("cid");
+    conn_options.client_id.size = 3;
+    conn_options.will.topic.buf_p = FSTR("wtop");
+    conn_options.will.topic.size = 4;
+    conn_options.will.payload.buf_p = FSTR("wpay");
+    conn_options.will.payload.size = 4;
+    conn_options.user_name.buf_p = FSTR("john");
+    conn_options.user_name.size = 4;
+    conn_options.password.buf_p = FSTR("secret");
+    conn_options.password.size = 6;
+
     /* Prepare the server to receive the connection message. */
     message.buf_p = NULL;
-    message.size = 14;
+    message.size = 2 + 10 + 5 + 6 + 6 + 6 + 8;
     BTASSERT(queue_write(&qserverin, &message, sizeof(message)) == sizeof(message));
 
     /* Prepare the server to send the connection ack message. */
@@ -161,13 +176,13 @@ static int test_connect(void)
     BTASSERT(queue_write(&qserverin, &message, sizeof(message)) == sizeof(message));
 
     /* Connect. */
-    BTASSERTI(mqtt_client_connect(&client), ==, 0);
+    BTASSERTI(mqtt_client_connect(&client, &conn_options), ==, 0);
 
     BTASSERTI(queue_read(&qserverout, buf, 2), ==, 2);
     BTASSERTI(buf[0], ==, 0x10);
-    BTASSERTI(buf[1], ==, 12);
+    BTASSERTI(buf[1], ==, 10 + 5 + 6 + 6 + 6 + 8);
 
-    BTASSERTI(queue_read(&qserverout, buf, 12), ==, 12);
+    BTASSERTI(queue_read(&qserverout, buf, 10), ==, 10);
     BTASSERTI(buf[0], ==, 0);
     BTASSERTI(buf[1], ==, 4);
     BTASSERTI(buf[2], ==, 'M');
@@ -175,11 +190,50 @@ static int test_connect(void)
     BTASSERTI(buf[4], ==, 'T');
     BTASSERTI(buf[5], ==, 'T');
     BTASSERTI(buf[6], ==, 4);
-    BTASSERTI(buf[7], ==, 0x02);
-    BTASSERTI(buf[8], ==, 1);
-    BTASSERTI(buf[9], ==, 0x2c);
-    BTASSERTI(buf[10], ==, 0);
-    BTASSERTI(buf[11], ==, 0);
+    BTASSERTI(buf[7], ==, 0xc6);
+    BTASSERTI(buf[8], ==, 0x10);
+    BTASSERTI(buf[9], ==, 0x92);
+
+    BTASSERTI(queue_read(&qserverout, buf, 5), ==, 5);
+    BTASSERTI(buf[0], ==, 0);
+    BTASSERTI(buf[1], ==, 3);
+    BTASSERTI(buf[2], ==, 'c');
+    BTASSERTI(buf[3], ==, 'i');
+    BTASSERTI(buf[4], ==, 'd');
+
+    BTASSERTI(queue_read(&qserverout, buf, 6), ==, 6);
+    BTASSERTI(buf[0], ==, 0);
+    BTASSERTI(buf[1], ==, 4);
+    BTASSERTI(buf[2], ==, 'w');
+    BTASSERTI(buf[3], ==, 't');
+    BTASSERTI(buf[4], ==, 'o');
+    BTASSERTI(buf[5], ==, 'p');
+
+    BTASSERTI(queue_read(&qserverout, buf, 6), ==, 6);
+    BTASSERTI(buf[0], ==, 0);
+    BTASSERTI(buf[1], ==, 4);
+    BTASSERTI(buf[2], ==, 'w');
+    BTASSERTI(buf[3], ==, 'p');
+    BTASSERTI(buf[4], ==, 'a');
+    BTASSERTI(buf[5], ==, 'y');
+
+    BTASSERTI(queue_read(&qserverout, buf, 6), ==, 6);
+    BTASSERTI(buf[0], ==, 0);
+    BTASSERTI(buf[1], ==, 4);
+    BTASSERTI(buf[2], ==, 'j');
+    BTASSERTI(buf[3], ==, 'o');
+    BTASSERTI(buf[4], ==, 'h');
+    BTASSERTI(buf[5], ==, 'n');
+
+    BTASSERTI(queue_read(&qserverout, buf, 8), ==, 8);
+    BTASSERTI(buf[0], ==, 0);
+    BTASSERTI(buf[1], ==, 6);
+    BTASSERTI(buf[2], ==, 's');
+    BTASSERTI(buf[3], ==, 'e');
+    BTASSERTI(buf[4], ==, 'c');
+    BTASSERTI(buf[5], ==, 'r');
+    BTASSERTI(buf[6], ==, 'e');
+    BTASSERTI(buf[7], ==, 't');
 
     return (0);
 }

--- a/tst/inet/mqtt_client_network/main.c
+++ b/tst/inet/mqtt_client_network/main.c
@@ -103,7 +103,7 @@ static int test_init(void)
 
 static int test_connect(void)
 {
-    BTASSERT(mqtt_client_connect(&client) == 0);
+    BTASSERT(mqtt_client_connect(&client, NULL) == 0);
 
     return (0);
 }


### PR DESCRIPTION
This allows setting client id, username, password, and Last Will and
Testament in MQTT connection options.

Setting this is done through a parameter to
mqtt_client_connect(). While this changes the API, it seems like the
best aproach as it allows the client not to have to keep any state for
the new options and therefor do not increase memory consumption other
than during connect.

The change is made so it's very easy for existing code to be updated,
as it simply need to change connect call from:

  mqtt_client_connect(client);

to:

  mqtt_client_connect(client, NULL);

to preserve existing behaviour.

While here update the documentation.

This has been tested against real MQTT brokers io.adafruit.com and
test.mosquitto.org.

Fixes #109.
Fixes #110.