### PR TITLE
Improve I2C soft compat documentation.

### DIFF
--- a/doc/library-reference/drivers/network/i2c.rst
+++ b/doc/library-reference/drivers/network/i2c.rst
@@ -15,8 +15,8 @@ requirements. In this implementation the slave will always send an
 acknowledgement when addressed by the master, and lock the bus by
 pulling SCL low until it is ready for the transmission.
 
-This driver is for systems with hardware I2C support. For systems
-without hardware I2C support the :doc:`i2c_soft` driver can be used.
+For systems without hardware I2C, the :doc:`i2c_soft` driver will
+supply I2C devices though the interface documented in this driver.
 
 --------------------------------------------------
 

--- a/doc/library-reference/mcus/esp32.rst
+++ b/doc/library-reference/mcus/esp32.rst
@@ -4,6 +4,21 @@
 .. module:: esp32
    :synopsis: Esp32.
 
+I2C
+---
+
+Simba does not yet support the ESP32 hardware I2C support, but can use
+the :doc:`../drivers/network/i2c_soft` driver instead. By default one
+:doc:`../drivers/network/i2c` compatability device is instantiated:
+
+====== ====== =======
+Device SCL    SDA
+====== ====== =======
+i2c0   Pin 22 Pin 21
+====== ====== =======
+
+----------------------------------------------
+
 Hardware reference: https://github.com/eerimoq/hardware-reference/tree/master/esp32
 
 Source code: :github-blob:`src/mcus/esp32/mcu.h`

--- a/doc/library-reference/mcus/esp8266.rst
+++ b/doc/library-reference/mcus/esp8266.rst
@@ -4,6 +4,22 @@
 .. module:: esp8266
    :synopsis: Esp8266.
 
+I2C
+---
+
+The ESP8266 does not have hardware I2C support, but can use the
+:doc:`../drivers/network/i2c_soft` driver instead. By default two
+:doc:`../drivers/network/i2c` compatability devices are instantiated:
+
+====== ====== =======
+Device SCL    SDA
+====== ====== =======
+i2c0   GPIO5  GPIO4
+i2c1   GPIO12 GPIO13
+====== ====== =======
+
+--------------------------------------------------
+
 Hardware reference: https://github.com/eerimoq/hardware-reference/tree/master/esp8266
 
 Source code: :github-blob:`src/mcus/esp8266/mcu.h`


### PR DESCRIPTION
- Update i2c page to say i2c_soft provides compat.
- Add pin information to ESP32 and ESP8266 pages.