### PR TITLE
Initialize ESP driver to station mode by default.

### DIFF
--- a/src/drivers/network/esp_wifi.h
+++ b/src/drivers/network/esp_wifi.h
@@ -35,6 +35,11 @@
 
 /**
  * WiFi operational mode.
+ *
+ * \note The driver code rely on the combined station + softap mode
+ *       being bitwise-or of station and softap mode, and the enum
+ *       integer values of the modes matching the ESP8266 SDKs values
+ *       for the modes.
  */
 enum esp_wifi_op_mode_t {
     esp_wifi_op_mode_null_t = 0,

--- a/src/inet/network_interface/driver/esp.c
+++ b/src/inet/network_interface/driver/esp.c
@@ -32,8 +32,24 @@
 
 #if CONFIG_ESP_WIFI == 1
 
+static int module_initialized = 0;
+
 static int esp_station_init(void *arg_p)
 {
+    /* Return immediately if the module is already initialized. */
+    if (module_initialized == 1) {
+        return (0);
+    }
+
+    module_initialized = 1;
+
+    /*
+     * Set station mode by default, esp_station_start() by default
+     * will only set station mode, but if the application has enabled
+     * the AP mode, we won't disable that.
+     */
+    esp_wifi_set_op_mode(esp_wifi_op_mode_station_t);
+
     return (0);
 }
 
@@ -44,6 +60,11 @@ static int esp_station_start(void *arg_p,
 {
     int mode;
 
+    /*
+     * If the application has enabled AP mode, we will keep the AP
+     * running by switching to station + AP mode, instead of just AP
+     * mode.
+     */
     mode = esp_wifi_get_op_mode();
     mode |= esp_wifi_op_mode_station_t;
 


### PR DESCRIPTION
Without this the high level network_interface_wifi, including users
of CONFIG_START_NETWORK, may end up with an access point running using
the default name (e.g. ESP_XXXXXX) which does not seem to be
intentional.

A user can still explicitly enable the softap mode and use
network_interface_wifi.

While here add some comments to esp_wifi_op_mode_t and the esp driver
making it more clear how some of the code and enum values work / are
used.