### PR TITLE
add wemos d1 mini to supported platforms

### DIFF
--- a/make/platformio/platformio.py
+++ b/make/platformio/platformio.py
@@ -79,7 +79,8 @@ SUPPORTED_BOARDS = [
     "nodemcu",
     "huzzah",
     "nano32",
-    "esp32_devkitc"
+    "esp32_devkitc",
+    "wemos_d1_mini"
 ]
 
 


### PR DESCRIPTION
Add WeMos D1 mini to  supported boards.