### PR TITLE
Add Default Settings section into User Guide docs

### DIFF
--- a/bin/dbgen.py
+++ b/bin/dbgen.py
@@ -39,7 +39,8 @@ def get_make_variable(board, variable):
                                     "-s",
                                     "BOARD=" + board,
                                     "print-" + variable],
-                                   cwd="examples/default-configuration")
+                                   cwd="examples/default-configuration",
+                                   universal_newlines=True)
 
 
 def get_default_configuration(board):
@@ -51,7 +52,8 @@ def get_default_configuration(board):
                                     "-s",
                                     "BOARD=" + board,
                                     "default-configuration"],
-                                   cwd="examples/default-configuration")
+                                   cwd="examples/default-configuration",
+                                   universal_newlines=True)
 
 
 def get_port_has(board):
@@ -63,7 +65,8 @@ def get_port_has(board):
                                     "-s",
                                     "BOARD=" + board,
                                     "port-has"],
-                                   cwd="examples/default-configuration")
+                                   cwd="examples/default-configuration",
+                                   universal_newlines=True)
 
 
 def main():

--- a/bin/docgen.py
+++ b/bin/docgen.py
@@ -258,8 +258,7 @@ def testing_generate(database):
     testing_suites_path = os.path.join("doc", "developer-guide", "testing-suites.rst")
 
     with open(testing_suites_path, "w") as fout:
-        boards = database["boards"].keys()
-        boards.sort()
+        boards = sorted(database["boards"].keys())
         for board in boards:
             suites = subprocess.check_output([
                 'make',

--- a/bin/docgen.py
+++ b/bin/docgen.py
@@ -180,7 +180,8 @@ def boards_generate(database):
                     '-C', os.path.join('examples', application),
                     'BOARD=' + board,
                     'size-json'
-                ])
+                ],
+                universal_newlines=True)
                 sizes = json.loads(sizes_json)
                 memory_usage.append(
                     '| {application:24} | {program:9} | {data:9} |'.format(
@@ -265,7 +266,8 @@ def testing_generate(database):
                 '-s',
                 'BOARD=' + board,
                 'print-TESTS'
-            ])
+            ],
+            universal_newlines=True)
             print(database["boards"][board]["board_desc"], file=fout)
             print('-' * len(board), file=fout)
             print(file=fout)

--- a/bin/docgen.py
+++ b/bin/docgen.py
@@ -72,7 +72,7 @@ Below is the memory usage of two applications:
 Default configuration
 ---------------------
 
-Default configuration of the UART: {features_params[console_br]}-8-N-1
+The communication between the PC and the board is carried over **{features_params[comm_channel]}{features_params[channel_params]}**.
 
 Default Standard Library configuration.
 
@@ -160,8 +160,22 @@ def boards_generate(database):
                 major_features.append("- :doc:`Console.<../library-reference/oam/console>`")
             if name == "CONFIG_START_SHELL" and value == "1":
                 major_features.append("- :doc:`Debug shell.<../library-reference/oam/shell>`")
-            if name == "CONFIG_START_CONSOLE_UART_BAUDRATE":
-                features_params["console_br"] = value
+
+            # The system console's communication channel
+            if name == "CONFIG_START_CONSOLE":
+                if value == "CONFIG_START_CONSOLE_UART":
+                    features_params["comm_channel"] = "UART"
+                elif value == "CONFIG_START_CONSOLE_USB_CDC":
+                    features_params["comm_channel"] = "USB"
+                    features_params["channel_params"] = ""
+                else:
+                    features_params["comm_channel"] = "unknown"
+                    features_params["channel_params"] = ""
+
+            # The communication channel parameters (nothing for USB)
+            if name == "CONFIG_START_CONSOLE_UART_BAUDRATE" and \
+                    features_params["comm_channel"] == "UART":
+                features_params["channel_params"] = " {}-8-N-1".format(value)
 
         # Memory usage.
         applications = [

--- a/bin/docgen.py
+++ b/bin/docgen.py
@@ -72,6 +72,8 @@ Below is the memory usage of two applications:
 Default configuration
 ---------------------
 
+Default configuration of the UART: {features_params[console_br]}-8-N-1
+
 Default Standard Library configuration.
 
 +--------------------------------------------------------+-----------------------------------------------------+
@@ -148,6 +150,7 @@ def boards_generate(database):
 
         # Enabled features.
         major_features = []
+        features_params = {}
         for [name, value] in data["default-configuration"]:
             if name == "CONFIG_START_NETWORK" and value == "1":
                 major_features.append("- Networking.")
@@ -157,6 +160,8 @@ def boards_generate(database):
                 major_features.append("- :doc:`Console.<../library-reference/oam/console>`")
             if name == "CONFIG_START_SHELL" and value == "1":
                 major_features.append("- :doc:`Debug shell.<../library-reference/oam/shell>`")
+            if name == "CONFIG_START_CONSOLE_UART_BAUDRATE":
+                features_params["console_br"] = value
 
         # Memory usage.
         applications = [
@@ -206,7 +211,8 @@ def boards_generate(database):
             include_extra=include_extra,
             targets='\n\n'.join(targets),
             memory_usage='\n+-{}-+-----------+-----------+\n'.format(
-                24 * '-').join(memory_usage))
+                24 * '-').join(memory_usage),
+            features_params=features_params)
 
         rst_path = os.path.join("doc", "boards", board + ".rst")
         print("Writing to ", rst_path)

--- a/doc/user-guide/configuration.rst
+++ b/doc/user-guide/configuration.rst
@@ -41,6 +41,17 @@ Arduino IDE
 
 2. The default configuration file, :github-blob:`src/config_default.h`.
 
+Default Settings
+^^^^^^^^^^^^^^^^
+In this section you can find some important and widly used settings.
+
+Console UART
+""""""""""""
+
+The default configuration of the system console's UART can be found at the page
+of particular boards in the :doc:`../boards` in the Default Configuration
+section.
+
 Variables
 ^^^^^^^^^
 

--- a/doc/user-guide/configuration.rst
+++ b/doc/user-guide/configuration.rst
@@ -43,6 +43,7 @@ Arduino IDE
 
 Default Settings
 ^^^^^^^^^^^^^^^^
+
 In this section you can find some important and widly used settings.
 
 Console UART


### PR DESCRIPTION
Add missing documentation about serial port settings #188.

I thought that there could be another default settings which need to be mentioned, so, I added the Serial port section under the Default Settings section.