### PR TITLE
Enable DHT sensor driver for esp8266

### DIFF
--- a/src/config_default.h
+++ b/src/config_default.h
@@ -117,6 +117,7 @@
 #    define PORT_HAS_SPI
 #    define PORT_HAS_UART_SOFT
 #    define PORT_HAS_POWER
+#    define PORT_HAS_DHT
 #endif
 
 #if defined(FAMILY_ESP32)

--- a/src/drivers/sensors/dht.c
+++ b/src/drivers/sensors/dht.c
@@ -188,7 +188,7 @@ int dht_init(struct dht_driver_t *self_p,
     return (0);
 }
 
-static int dht_read_sensor(struct dht_driver_t *self_p, uint8_t *buf_p)
+static int read_sensor(struct dht_driver_t *self_p, uint8_t *buf_p)
 {
     int res;
 
@@ -226,7 +226,8 @@ int dht_read(struct dht_driver_t *self_p,
     int negative;
     uint8_t buf[DATA_SIZE];
 
-    res = dht_read_sensor(self_p, &buf[0]);
+    res = read_sensor(self_p, &buf[0]);
+
     if (res < 0) {
         return (res);
     }
@@ -247,14 +248,15 @@ int dht_read(struct dht_driver_t *self_p,
     return (0);
 }
 
-int dht_read11(struct dht_driver_t *self_p,
+int dht_11_read(struct dht_driver_t *self_p,
                float *temperature_p,
                float *humidty_p)
 {
     int res;
     uint8_t buf[DATA_SIZE];
 
-    res = dht_read_sensor(self_p, &buf[0]);
+    res = read_sensor(self_p, &buf[0]);
+    
     if (res < 0) {
         return (res);
     }

--- a/src/drivers/sensors/dht.c
+++ b/src/drivers/sensors/dht.c
@@ -188,15 +188,11 @@ int dht_init(struct dht_driver_t *self_p,
     return (0);
 }
 
-int dht_read(struct dht_driver_t *self_p,
-             float *temperature_p,
-             float *humidty_p)
+int dht_read_sensor(struct dht_driver_t *self_p, uint8_t *buf_p)
 {
     int res;
-    int negative;
-    uint8_t buf[DATA_SIZE];
 
-    memset(&buf[0], 0, sizeof(buf));
+    memset(&buf_p[0], 0, DATA_SIZE);
 
     /* Device communication. Start start signal by setting the pin
        low. */
@@ -204,7 +200,7 @@ int dht_read(struct dht_driver_t *self_p,
     thrd_sleep_ms(1);
 
     sys_lock();
-    res = read_isr(self_p, &buf[0]);
+    res = read_isr(self_p, &buf_p[0]);
     sys_unlock();
 
     pin_device_set_mode(self_p->pin_p, PIN_OUTPUT);
@@ -215,8 +211,24 @@ int dht_read(struct dht_driver_t *self_p,
     }
 
     /* Check the parity bits. */
-    if (!is_valid(&buf[0])) {
+    if (!is_valid(&buf_p[0])) {
         return (-EPROTO);
+    }
+
+    return 0;
+}
+
+int dht_read(struct dht_driver_t *self_p,
+             float *temperature_p,
+             float *humidty_p)
+{
+    int res;
+    int negative;
+    uint8_t buf[DATA_SIZE];
+
+    res = dht_read_sensor(self_p, &buf[0]);
+    if (res < 0) {
+        return (res);
     }
 
     /* Temperature and humidty unpacking and convertion. */
@@ -231,6 +243,25 @@ int dht_read(struct dht_driver_t *self_p,
 
     *humidty_p = ((buf[HUMID_MSB_INDEX] << 8) | buf[HUMID_LSB_INDEX]);
     *humidty_p /= 10.0f;
+
+    return (0);
+}
+
+int dht_read11(struct dht_driver_t *self_p,
+               float *temperature_p,
+               float *humidty_p)
+{
+    int res;
+    uint8_t buf[DATA_SIZE];
+
+    res = dht_read_sensor(self_p, &buf[0]);
+    if (res < 0) {
+        return (res);
+    }
+
+    /* Temperature and humidty unpacking and convertion. */
+    *temperature_p = ((buf[TEMP_MSB_INDEX]) + buf[TEMP_LSB_INDEX] / 10.0f);
+    *humidty_p = buf[HUMID_MSB_INDEX];
 
     return (0);
 }

--- a/src/drivers/sensors/dht.c
+++ b/src/drivers/sensors/dht.c
@@ -188,7 +188,7 @@ int dht_init(struct dht_driver_t *self_p,
     return (0);
 }
 
-int dht_read_sensor(struct dht_driver_t *self_p, uint8_t *buf_p)
+static int dht_read_sensor(struct dht_driver_t *self_p, uint8_t *buf_p)
 {
     int res;
 

--- a/src/drivers/sensors/dht.h
+++ b/src/drivers/sensors/dht.h
@@ -64,7 +64,7 @@ int dht_init(struct dht_driver_t *self_p,
              struct pin_device_t *pin_p);
 
 /**
- * Read temperature and humidity from the device.
+ * Read temperature and humidity from the DHT21/22 device.
  *
  * CAUTION: This function disables interrupts for up to 5 ms, which
  *          may cause problems for other timing critical
@@ -80,4 +80,20 @@ int dht_read(struct dht_driver_t *self_p,
              float *temperature_p,
              float *humidty_p);
 
+/**
+ * Read temperature and humidity from the DHT11 device.
+ *
+ * CAUTION: This function disables interrupts for up to 5 ms, which
+ *          may cause problems for other timing critical
+ *          functionality.
+ *
+ * @param[in] self_p Driver object.
+ * @param[out] temperature_p Temperature in degrees Celsius, or NULL.
+ * @param[out] humidity_p Humidity in relative humidty %RH, or NULL.
+ *
+ * @return zero(0) or negative error code.
+ */
+int dht_read11(struct dht_driver_t *self_p,
+               float *temperature_p,
+               float *humidty_p);
 #endif

--- a/src/drivers/sensors/dht.h
+++ b/src/drivers/sensors/dht.h
@@ -93,7 +93,7 @@ int dht_read(struct dht_driver_t *self_p,
  *
  * @return zero(0) or negative error code.
  */
-int dht_read11(struct dht_driver_t *self_p,
-               float *temperature_p,
-               float *humidty_p);
+int dht_11_read(struct dht_driver_t *self_p,
+                float *temperature_p,
+                float *humidty_p);
 #endif

--- a/src/kernel/ports/esp/gnu/time_port.i
+++ b/src/kernel/ports/esp/gnu/time_port.i
@@ -27,6 +27,7 @@
  */
 
 #include "esp_misc.h"
+#include "esp_system.h"
 
 static void time_port_busy_wait_us(int microseconds)
 {
@@ -35,7 +36,7 @@ static void time_port_busy_wait_us(int microseconds)
 
 static int time_port_micros(void)
 {
-    return (-ENOSYS);
+    return (system_get_time());
 }
 
 static int time_port_micros_maximum(void)


### PR DESCRIPTION
Enables dht module for esp8266 mcu. Also adds new function dht_read11() to read data from DHT11 sensor, which requires slightly different decoding.