### PR TITLE
Fix missing PWM frequency configuration for AVR port

### DIFF
--- a/src/drivers/basic/analog_output_pin.c
+++ b/src/drivers/basic/analog_output_pin.c
@@ -46,10 +46,12 @@ int analog_output_pin_init(struct analog_output_pin_t *self_p,
         return (-1);
     }
     
-    return (pwm_init(&self_p->pwm,
-                     pwm_p,
-                     pwm_frequency(10000),
-                     pwm_duty_cycle(0)));
+    pwm_init(&self_p->pwm,
+             pwm_p,
+             pwm_frequency(10000),
+             pwm_duty_cycle(0));
+
+    return (pwm_start(&self_p->pwm));
 }
 
 int analog_output_pin_write(struct analog_output_pin_t *self_p,


### PR DESCRIPTION
Fixes #175

The analog_output_pin_init function initialize the pwm pin. Then, analog_output_pin_write configure duty cycle of the PWM module but doesn't set frequency (via setting compare register). The code for configuring compare register is placed at the pwm_port_set_frequency function.

The pwm_start function sets frequency + duty cycle (by calling pwm_port_set_frequency). So, by calling the pwm_start function between initialization and write fix the issue.

I'm not sure where to place this call in the analog_output_pin_init or analog_output_pin_write with some handling if freq. is already set.